### PR TITLE
Recovery x api

### DIFF
--- a/icc-x-api/crypto/BaseExchangeDataManager.ts
+++ b/icc-x-api/crypto/BaseExchangeDataManager.ts
@@ -287,6 +287,24 @@ export class BaseExchangeDataManager {
     }
   }
 
+  async tryRawDecryptExchangeData(
+    exchangeData: ExchangeData,
+    decryptionKeys: { [publicKeyFingerprint: string]: KeyPair<CryptoKey> }
+  ): Promise<
+    | {
+        rawExchangeKey: ArrayBuffer
+        rawAccessControlSecret: ArrayBuffer
+        rawSharedSignatureKey: ArrayBuffer
+      }
+    | undefined
+  > {
+    const rawExchangeKey = await this.tryDecrypt(exchangeData.exchangeKey, decryptionKeys)
+    const rawAccessControlSecret = await this.tryDecrypt(exchangeData.accessControlSecret, decryptionKeys)
+    const rawSharedSignatureKey = await this.tryDecrypt(exchangeData.sharedSignatureKey, decryptionKeys)
+    if (!rawExchangeKey || !rawAccessControlSecret || !rawSharedSignatureKey) return undefined
+    return { rawExchangeKey, rawAccessControlSecret, rawSharedSignatureKey }
+  }
+
   /**
    * Updates existing exchange data and uploads it to the cloud in order to share it also with additional public keys, useful for example in cases
    * where one of the data owners involved in the exchange data has lost one of his keys.

--- a/icc-x-api/crypto/CryptoStrategies.ts
+++ b/icc-x-api/crypto/CryptoStrategies.ts
@@ -2,6 +2,7 @@ import { KeyPair } from './RSA'
 import { CryptoPrimitives } from './CryptoPrimitives'
 import { CryptoActorStubWithType } from '../../icc-api/model/CryptoActorStub'
 import { DataOwnerWithType } from '../../icc-api/model/DataOwnerWithType'
+import { KeyPairRecoverer } from './KeyPairRecoverer'
 
 /**
  * Allows to customise the behaviour of the crypto api to better suit your needs.
@@ -37,6 +38,7 @@ export interface CryptoStrategies {
    *   value won't be cached (will be again part of `unknownKeys` in future instances.
    * @param keysData all information on unknown and unavailable keys for each data owner part of the current data owner hierarchy.
    * @param cryptoPrimitives cryptographic primitives you can use to support the process.
+   * @param keyPairRecoverer a key pair recoverer.
    * @return all recovered keys and key authenticity information, by data owner.
    */
   recoverAndVerifySelfHierarchyKeys(
@@ -45,7 +47,8 @@ export interface CryptoStrategies {
       unknownKeys: string[]
       unavailableKeys: string[]
     }[],
-    cryptoPrimitives: CryptoPrimitives
+    cryptoPrimitives: CryptoPrimitives,
+    keyPairRecoverer: KeyPairRecoverer
   ): Promise<{
     [dataOwnerId: string]: {
       recoveredKeys: { [keyPairFingerprint: string]: KeyPair<CryptoKey> }

--- a/icc-x-api/crypto/ExchangeDataManager.ts
+++ b/icc-x-api/crypto/ExchangeDataManager.ts
@@ -93,12 +93,15 @@ export interface ExchangeDataManager {
    * @param delegateId the id of the delegate.
    * @param entityType type of the entity for which you want to create new metadata.
    * @param entitySecretForeignKeys the secret foreign keys of the entity which you want to create new metadata.
+   * @param allowCreationWithoutDelegateKey if true, when creating new exchange data, even if no verified key is available for the delegate the method
+   * will create the new exchange data anyway (will not be usable by the delegate without additional steps).
    * @return the access control secret and key of the data to use for encryption.
    */
   getOrCreateEncryptionDataTo(
     delegateId: string,
     entityType: EntityWithDelegationTypeName | undefined,
-    entitySecretForeignKeys: string[] | undefined
+    entitySecretForeignKeys: string[] | undefined,
+    allowCreationWithoutDelegateKey: boolean
   ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey }>
 
   /**
@@ -204,7 +207,10 @@ abstract class AbstractExchangeDataManager implements ExchangeDataManager {
 
   protected async createNewExchangeData(
     delegateId: string,
-    newDataId?: string
+    options: {
+      newDataId?: string
+      allowNoDelegateKeys?: boolean
+    }
   ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey }> {
     const encryptionKeys: { [fp: string]: CryptoKey } = {}
     this.encryptionKeys.getSelfVerifiedKeys().forEach(({ fingerprint, pair }) => {
@@ -215,7 +221,9 @@ abstract class AbstractExchangeDataManager implements ExchangeDataManager {
       const sha256KeysOfDelegate = hexPublicKeysWithSha256Of(delegate.stub)
       const sha1KeysOfDelegate = hexPublicKeysWithSha1Of(delegate.stub)
       let allVerifiedDelegateKeys: string[]
-      if (this.useParentKeys && (await this.dataOwnerApi.getCurrentDataOwnerHierarchyIds()).includes(delegateId)) {
+      if (!sha256KeysOfDelegate.size && !sha1KeysOfDelegate.size) {
+        allVerifiedDelegateKeys = []
+      } else if (this.useParentKeys && (await this.dataOwnerApi.getCurrentDataOwnerHierarchyIds()).includes(delegateId)) {
         allVerifiedDelegateKeys = await this.encryptionKeys.getVerifiedPublicKeysFor(delegate.stub)
       } else {
         allVerifiedDelegateKeys = await this.cryptoStrategies.verifyDelegatePublicKeys(
@@ -224,7 +232,7 @@ abstract class AbstractExchangeDataManager implements ExchangeDataManager {
           this.primitives
         )
       }
-      if (!allVerifiedDelegateKeys.length)
+      if (!allVerifiedDelegateKeys.length && !options.allowNoDelegateKeys)
         throw new Error(`Could not create exchange data to ${delegateId} as no public key for the delegate could be verified.`)
       for (const delegateKey of allVerifiedDelegateKeys) {
         if (sha1KeysOfDelegate.has(delegateKey)) {
@@ -239,7 +247,7 @@ abstract class AbstractExchangeDataManager implements ExchangeDataManager {
       delegateId,
       { [signatureKey.fingerprint]: signatureKey.keyPair.privateKey },
       encryptionKeys,
-      newDataId ? { id: newDataId } : {}
+      options.newDataId ? { id: options.newDataId } : {}
     )
     return {
       exchangeData: newData.exchangeData,
@@ -281,7 +289,8 @@ abstract class AbstractExchangeDataManager implements ExchangeDataManager {
   getOrCreateEncryptionDataTo(
     delegateId: string,
     entityType: EntityWithDelegationTypeName | undefined,
-    entitySecretForeignKeys: string[] | undefined
+    entitySecretForeignKeys: string[] | undefined,
+    allowCreationWithoutDelegateKey: boolean
   ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey }> {
     throw new Error('Implemented by concrete class')
   }
@@ -375,7 +384,8 @@ class FullyCachedExchangeDataManager extends AbstractExchangeDataManager {
   async getOrCreateEncryptionDataTo(
     delegateId: string,
     entityType: EntityWithDelegationTypeName | undefined,
-    entitySecretForeignKeys: string[] | undefined
+    entitySecretForeignKeys: string[] | undefined,
+    allowCreationWithoutDelegateKey: boolean
   ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey }> {
     const caches = await this.caches
     const dataId = caches.delegateToVerifiedEncryptionDataId[delegateId]
@@ -387,7 +397,7 @@ class FullyCachedExchangeDataManager extends AbstractExchangeDataManager {
         exchangeKey: cached.decrypted.exchangeKey,
       }
     }
-    const created = await this.createNewExchangeData(delegateId)
+    const created = await this.createNewExchangeData(delegateId, { allowNoDelegateKeys: allowCreationWithoutDelegateKey })
     this.cacheData(
       created.exchangeData,
       { accessControlSecret: created.accessControlSecret, exchangeKey: created.exchangeKey, verified: true },
@@ -623,7 +633,8 @@ class LimitedLruCacheExchangeDataManager extends AbstractExchangeDataManager {
   async getOrCreateEncryptionDataTo(
     delegateId: string,
     entityType: EntityWithDelegationTypeName | undefined,
-    entitySecretForeignKeys: string[] | undefined
+    entitySecretForeignKeys: string[] | undefined,
+    allowCreationWithoutDelegateKey: boolean
   ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey }> {
     let existingId = this.delegateToVerifiedEncryptionDataId.get(delegateId)
     if (!existingId) {
@@ -645,7 +656,7 @@ class LimitedLruCacheExchangeDataManager extends AbstractExchangeDataManager {
       this.delegateToVerifiedEncryptionDataId.set(delegateId, newDataId)
       const createdAndCachedData = await this.idToDataCache.get(newDataId, () =>
         this.cacheJob(async () => {
-          const created = await this.createNewExchangeData(delegateId, newDataId)
+          const created = await this.createNewExchangeData(delegateId, { newDataId, allowNoDelegateKeys: allowCreationWithoutDelegateKey })
           const hashes = await this.secureDelegationKeysForAllEntitiesNoSfkAndSpecificEntitySfksPairs(
             created.accessControlSecret,
             entityType,

--- a/icc-x-api/crypto/KeyPairRecoverer.ts
+++ b/icc-x-api/crypto/KeyPairRecoverer.ts
@@ -1,12 +1,15 @@
 import { KeyPair } from './RSA'
-import { RecoveryDataUseFailureReason } from './RecoveryDataEncryption'
+import { RecoveryDataEncryption, RecoveryDataUseFailureReason } from './RecoveryDataEncryption'
+import { IccRecoveryDataApi } from '../../icc-api/api/internal/IccRecoveryDataApi'
 
 /**
  * Allows to recover user keypairs using builtin recovery mechanisms.
  * This interface includes recovery methods that require some input from your application (e.g. a recovery key created from a different device).
  * Other recovery methods (such as transfer keys) are used automatically by the sdk when available and don't require any input from your application.
  */
-export interface KeyPairRecoverer {
+export class KeyPairRecoverer {
+  constructor(private readonly recoveryDataEncryption: RecoveryDataEncryption, private readonly baseRecoveryApi: IccRecoveryDataApi) {}
+
   /**
    * Recover a keypair using a recovery key created in the past using the {@link IccRecoveryXApi.createRecoveryInfoForAvailableKeyPairs} method.
    * @param recoveryKey the result of a past call to {@link IccRecoveryXApi.createRecoveryInfoForAvailableKeyPairs}.
@@ -24,5 +27,7 @@ export interface KeyPairRecoverer {
   recoverWithRecoveryKey(
     recoveryKey: string,
     autoDelete: boolean
-  ): Promise<{ success: { [dataOwnerId: string]: { [publicKeySpki: string]: KeyPair<CryptoKey> } } } | { failure: RecoveryDataUseFailureReason }>
+  ): Promise<{ success: { [dataOwnerId: string]: { [publicKeySpki: string]: KeyPair<CryptoKey> } } } | { failure: RecoveryDataUseFailureReason }> {
+    return this.recoveryDataEncryption.getAndDecryptKeyPairsRecoveryData(recoveryKey, autoDelete)
+  }
 }

--- a/icc-x-api/crypto/KeyPairRecoverer.ts
+++ b/icc-x-api/crypto/KeyPairRecoverer.ts
@@ -1,6 +1,5 @@
 import { KeyPair } from './RSA'
 import { RecoveryDataEncryption, RecoveryDataUseFailureReason } from './RecoveryDataEncryption'
-import { IccRecoveryDataApi } from '../../icc-api/api/internal/IccRecoveryDataApi'
 
 /**
  * Allows to recover user keypairs using builtin recovery mechanisms.
@@ -8,7 +7,7 @@ import { IccRecoveryDataApi } from '../../icc-api/api/internal/IccRecoveryDataAp
  * Other recovery methods (such as transfer keys) are used automatically by the sdk when available and don't require any input from your application.
  */
 export class KeyPairRecoverer {
-  constructor(private readonly recoveryDataEncryption: RecoveryDataEncryption, private readonly baseRecoveryApi: IccRecoveryDataApi) {}
+  constructor(private readonly recoveryDataEncryption: RecoveryDataEncryption) {}
 
   /**
    * Recover a keypair using a recovery key created in the past using the {@link IccRecoveryXApi.createRecoveryInfoForAvailableKeyPairs} method.

--- a/icc-x-api/crypto/KeyPairRecoverer.ts
+++ b/icc-x-api/crypto/KeyPairRecoverer.ts
@@ -1,0 +1,28 @@
+import { KeyPair } from './RSA'
+import { RecoveryDataUseFailureReason } from './RecoveryDataEncryption'
+
+/**
+ * Allows to recover user keypairs using builtin recovery mechanisms.
+ * This interface includes recovery methods that require some input from your application (e.g. a recovery key created from a different device).
+ * Other recovery methods (such as transfer keys) are used automatically by the sdk when available and don't require any input from your application.
+ */
+export interface KeyPairRecoverer {
+  /**
+   * Recover a keypair using a recovery key created in the past using the {@link IccRecoveryXApi.createRecoveryInfoForAvailableKeyPairs} method.
+   * @param recoveryKey the result of a past call to {@link IccRecoveryXApi.createRecoveryInfoForAvailableKeyPairs}.
+   * @param autoDelete if true, the recovery data will be deleted from the server after it could be used successfully.
+   * This will prevent the recovery key from being used again.
+   * @return an object containing a single `success` associated to an object in the form dataOwnerId -> publicKeySpki -> keyPair, where:
+   * - The `dataOwnerId` keys are the ids of the data owner which created the recovery data and his parents, if the recovery data contains also the
+   *   parents keys
+   * - The `publicKeySpki` keys are all public key pairs for the data owner, in hex-encoded spki format (full, no fingerprint)
+   * - The `keyPair` is the imported privateKey + publicKey.
+   *
+   * OR an object containing a single `failure` associated to a {@link RecoveryDataUseFailureReason} if the recovery data could not be used to
+   * perform the operation.
+   */
+  recoverWithRecoveryKey(
+    recoveryKey: string,
+    autoDelete: boolean
+  ): Promise<{ success: { [dataOwnerId: string]: { [publicKeySpki: string]: KeyPair<CryptoKey> } } } | { failure: RecoveryDataUseFailureReason }>
+}

--- a/icc-x-api/crypto/RecoveryDataEncryption.ts
+++ b/icc-x-api/crypto/RecoveryDataEncryption.ts
@@ -1,0 +1,162 @@
+import { KeyPair, ShaVersion } from './RSA'
+import { CryptoPrimitives } from './CryptoPrimitives'
+import { IccRecoveryDataApi } from '../../icc-api/api/internal/IccRecoveryDataApi'
+import { IccExchangeDataApi } from '../../icc-api/api/internal/IccExchangeDataApi'
+import { RecoveryData } from '../../icc-api/model/internal/RecoveryData'
+import { a2b, b2a, b64_2ua, hex2ua, string2ua, ua2b64, ua2hex, ua2string, ua2utf8, utf8_2ua } from '../utils'
+import { XHR } from '../../icc-api/api/XHR'
+import XHRError = XHR.XHRError
+import { ExchangeData } from '../../icc-api/model/internal/ExchangeData'
+import { KeyPairUpdateRequest } from '../maintenance/KeyPairUpdateRequest'
+
+export enum RecoveryDataUseFailureReason {
+  /**
+   * The recovery data matching the provided recovery key does not exist. It could have been deleted, or it could have been expired.
+   */
+  Missing = 'MISSING',
+  /**
+   * The recovery data exists but it is not available to the current user. The user may have used a recovery key that he created while logged in as
+   * a different user.
+   */
+  Unauthorized = 'UNAUTHORIZED',
+  /**
+   * The recovery data exists and is available to the current user, but it is not of the expected type.
+   */
+  InvalidType = 'INVALID_TYPE',
+  /**
+   * The recovery data exists and is available to the current user, but its content could not be interpreted. The data may have been created
+   * with an unsupported SDK version.
+   */
+  InvalidContent = 'INVALID_CONTENT',
+}
+
+// accessControlSecret, sharedSignatureKey, and exchangeKey all raw bytes b64 encoded
+type ExchangeDataRecoveryDataContent = {
+  exchangeDataId: string
+  rawAccessControlSecret: string
+  rawSharedSignatureKey: string
+  rawExchangeKey: string
+}[]
+// delegateId -> { pair: { privateKey: base64pkcs8, publicKey: base64spki }, algorithm: ShaVersion }[]
+type KeyPairRecoveryDataContent = { [delegateId: string]: { pair: KeyPair<string>; algorithm: ShaVersion }[] }
+type RecoveryDataContent = KeyPairRecoveryDataContent | ExchangeDataRecoveryDataContent
+
+/**
+ * @internal this class is for internal use only and may change without notice.
+ */
+export class RecoveryDataEncryption {
+  constructor(private readonly primitives: CryptoPrimitives, private readonly baseRecoveryApi: IccRecoveryDataApi) {}
+
+  async createAndSaveKeyPairsRecoveryDataFor(
+    recipient: string,
+    keyPairs: { [delegateId: string]: { pair: KeyPair<CryptoKey>; algorithm: ShaVersion }[] },
+    lifetimeSeconds: number | undefined
+  ): Promise<string> {
+    const content: KeyPairRecoveryDataContent = {}
+    for (const [delegateId, pairs] of Object.entries(keyPairs)) {
+      const entries: { pair: KeyPair<string>; algorithm: ShaVersion }[] = []
+      for (const { pair, algorithm } of pairs) {
+        entries.push({
+          pair: {
+            privateKey: ua2b64(await this.primitives.RSA.exportKey(pair.privateKey, 'pkcs8')),
+            publicKey: ua2b64(await this.primitives.RSA.exportKey(pair.publicKey, 'spki')),
+          },
+          algorithm,
+        })
+      }
+      content[delegateId] = entries
+    }
+    return await this.createRecoveryData(recipient, RecoveryData.Type.KEYPAIR_RECOVERY, lifetimeSeconds, content)
+  }
+
+  async getAndDecryptKeyPairsRecoveryData(
+    recoveryKey: string
+  ): Promise<{ succes: { [delegateId: string]: { [publicKeySpki: string]: KeyPair<CryptoKey> } } } | { failure: RecoveryDataUseFailureReason }> {
+    const getRecoveryDataResult = await this.getRecoveryDataAndDecrypt(recoveryKey, RecoveryData.Type.KEYPAIR_RECOVERY)
+    if ('failure' in getRecoveryDataResult) return getRecoveryDataResult
+    const recoveredKeysData = getRecoveryDataResult.decryptedJson as KeyPairRecoveryDataContent
+    const recoveredKeys: { [delegateId: string]: { [publicKeySpki: string]: KeyPair<CryptoKey> } } = {}
+    for (const [delegateId, pairs] of Object.entries(recoveredKeysData)) {
+      const delegateKeys: { [publicKeySpki: string]: KeyPair<CryptoKey> } = {}
+      for (const { pair, algorithm } of pairs) {
+        delegateKeys[ua2hex(b64_2ua(pair.publicKey))] = {
+          privateKey: await this.primitives.RSA.importKey('pkcs8', b64_2ua(pair.privateKey), ['decrypt'], algorithm),
+          publicKey: await this.primitives.RSA.importKey('spki', b64_2ua(pair.publicKey), ['encrypt'], algorithm),
+        }
+      }
+      recoveredKeys[delegateId] = delegateKeys
+    }
+    return { succes: recoveredKeys }
+  }
+
+  createAndSaveExchangeDataRecoveryData(
+    exchangeDataInfo: {
+      exchangeDataId: string
+      rawAccessControlSecret: ArrayBuffer
+      rawSharedSignatureKey: ArrayBuffer
+      rawExchangeKey: ArrayBuffer
+    }[],
+    lifetimeSeconds: number | undefined
+  ): Promise<string> {
+    throw 'TODO'
+  }
+
+  getAndDecryptExchangeDataRecoveryData(
+    recoveryKey: string
+  ): Promise<{ exchangeDataId: string; rawAccessControlSecret: ArrayBuffer; rawSharedSignatureKey: ArrayBuffer; rawExchangeKey: ArrayBuffer }[]> {
+    throw 'TODO'
+  }
+
+  async getRecoveryDataAndDecrypt(
+    recoveryKey: string,
+    expectedType: RecoveryData.Type
+  ): Promise<{ recoveryData: RecoveryData; decryptedJson: any } | { failure: RecoveryDataUseFailureReason }> {
+    const id = ua2hex(await this.primitives.sha256(hex2ua(recoveryKey)))
+    const getResult = await this.baseRecoveryApi.getRecoveryData(id).then(
+      (r) => ({ recoveryData: r }),
+      (e) => {
+        if (e instanceof XHRError) {
+          if (e.statusCode === 404) {
+            return { failure: RecoveryDataUseFailureReason.Missing }
+          } else if (e.statusCode === 403) {
+            return { failure: RecoveryDataUseFailureReason.Unauthorized }
+          }
+        }
+        throw e
+      }
+    )
+    if ('failure' in getResult) return getResult
+    const { recoveryData } = getResult
+    if (recoveryData.type !== expectedType) return { failure: RecoveryDataUseFailureReason.InvalidType }
+    const decryptionKey = await this.primitives.AES.importKey('raw', hex2ua(recoveryKey))
+    const decryptionResult = await this.primitives.AES.decrypt(decryptionKey, string2ua(a2b(recoveryData.encryptedSelf)))
+      .then((d) => JSON.parse(ua2utf8(d)))
+      .then(
+        (r): { success: RecoveryDataContent } => ({ success: r }),
+        () => ({ failure: RecoveryDataUseFailureReason.InvalidContent })
+      )
+    if ('failure' in decryptionResult) return decryptionResult
+    return { recoveryData, decryptedJson: decryptionResult.success }
+  }
+  async createRecoveryData(
+    recipient: string,
+    type: RecoveryData.Type,
+    lifetimeSeconds: number | undefined,
+    content: RecoveryDataContent
+  ): Promise<string> {
+    const recoveryKey = await this.primitives.AES.generateCryptoKey(false)
+    const recoveryKeyHex = ua2hex(await this.primitives.AES.exportKey(recoveryKey, 'raw'))
+    const id = ua2hex(await this.primitives.sha256(hex2ua(recoveryKeyHex)))
+    const encryptedSelf = b2a(ua2string(await this.primitives.AES.encrypt(recoveryKey, utf8_2ua(JSON.stringify(content)))))
+    const expirationInstant = lifetimeSeconds ? Date.now() + lifetimeSeconds * 1000 : undefined
+    const data: RecoveryData = new RecoveryData({
+      id,
+      encryptedSelf,
+      expirationInstant,
+      recipient,
+      type,
+    })
+    await this.baseRecoveryApi.createRecoveryData(data)
+    return recoveryKeyHex
+  }
+}

--- a/icc-x-api/crypto/SecureDelegationsManager.ts
+++ b/icc-x-api/crypto/SecureDelegationsManager.ts
@@ -141,7 +141,8 @@ export class SecureDelegationsManager {
     const exchangeDataInfo = await this.exchangeDataManager.getOrCreateEncryptionDataTo(
       delegateId,
       entityWithType.type,
-      entityWithType.entity.secretForeignKeys ?? []
+      entityWithType.entity.secretForeignKeys ?? [],
+      false
     )
     const accessControlHashes = await this.accessControlSecretUtils.secureDelegationKeysFor(
       exchangeDataInfo.accessControlSecret,
@@ -250,7 +251,8 @@ export class SecureDelegationsManager {
     const exchangeDataInfo = await this.exchangeDataManager.getOrCreateEncryptionDataTo(
       delegateId,
       entity.type,
-      entity.entity.secretForeignKeys ?? []
+      entity.entity.secretForeignKeys ?? [],
+      false
     )
     const accessControlHashes = await this.accessControlSecretUtils.secureDelegationKeysFor(
       exchangeDataInfo.accessControlSecret,

--- a/icc-x-api/crypto/ShamirKeysManager.ts
+++ b/icc-x-api/crypto/ShamirKeysManager.ts
@@ -65,7 +65,7 @@ export class ShamirKeysManager {
     const delegatesKeys: { [delegateId: string]: CryptoKey } = {}
     let updatedSelf = self
     for (const delegateId of new Set(Object.values(keySplitsToUpdate).flatMap((x) => x.notariesIds))) {
-      const res = await this.exchangeDataManager.getOrCreateEncryptionDataTo(delegateId, undefined, undefined)
+      const res = await this.exchangeDataManager.getOrCreateEncryptionDataTo(delegateId, undefined, undefined, false)
       delegatesKeys[delegateId] = res.exchangeKey
     }
     for (const [key, params] of Object.entries(keySplitsToUpdate)) {

--- a/icc-x-api/icc-crypto-x-api.ts
+++ b/icc-x-api/icc-crypto-x-api.ts
@@ -135,7 +135,7 @@ export class IccCryptoXApi {
     }
     parents: {
       dataOwnerId: string
-      keys: { pair: KeyPair<CryptoKey> }[]
+      keys: { pair: KeyPair<CryptoKey>; verified: boolean }[]
     }[]
   }> {
     return this._keyManager.getCurrentUserHierarchyAvailableKeypairs()

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -1266,7 +1266,10 @@ export class IccPatientXApi extends IccPatientApi implements EncryptedEntityXApi
    * @return true if exchange data was initialized, false if the patient already has a key pair and the exchange data
    * will be initialized in the standard way (automatically on the first time data is shared with the user).
    */
-  initialiseExchangeDataToNewlyInvitedPatient(patientId: string): Promise<boolean> {
-    throw 'TODO'
+  async forceInitialiseExchangeDataToNewlyInvitedPatient(patientId: string): Promise<boolean> {
+    const patient = await super.getPatient(patientId)
+    if (this.dataOwnerApi.getHexPublicKeysOf(patient).size) return false
+    await this.crypto.exchangeData.getOrCreateEncryptionDataTo(patientId, undefined, undefined, true)
+    return true
   }
 }

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -1248,4 +1248,25 @@ export class IccPatientXApi extends IccPatientApi implements EncryptedEntityXApi
   createDelegationDeAnonymizationMetadata(entity: Patient, delegates: string[]): Promise<void> {
     return this.crypto.delegationsDeAnonymization.createOrUpdateDeAnonymizationInfo({ entity, type: 'Patient' }, delegates)
   }
+
+  /**
+   * Initializes the exchange data towards a newly invited patient. This allows the doctor to share data with the
+   * patient even if the patient has not yet initialized a keypair for himself.
+   *
+   * This method should be used only if the patient has not yet initialized a keypair for himself. If the patient has
+   * already initialized a keypair this method does nothing and returns false. In this case the exchange data will be
+   * automatically created the first time you share data with the patient, and your implementation of the crypto
+   * strategies will be used to validate the public keys of the patient.
+   *
+   * Once exchange data is initialized you can use the {@link IccRecoveryXApi.createExchangeDataRecoveryInfo} to
+   * generate a key that the patient will be able to use on his first login to immediately gain access to the exchange
+   * data (through the {@link IccRecoveryXApi.recoverExchangeData} method).
+   *
+   * @param patientId the id of the newly invited patient.
+   * @return true if exchange data was initialized, false if the patient already has a key pair and the exchange data
+   * will be initialized in the standard way (automatically on the first time data is shared with the user).
+   */
+  initialiseExchangeDataToNewlyInvitedPatient(patientId: string): Promise<boolean> {
+    throw 'TODO'
+  }
 }

--- a/icc-x-api/icc-recovery-x-api.ts
+++ b/icc-x-api/icc-recovery-x-api.ts
@@ -103,7 +103,7 @@ export class IccRecoveryXApi {
    *   identify the delegate instead of validating that the public key belongs to the delegate.
    * - A patient is not yet registered in the system and therefore has no keypair, but the doctor wants to already share
    *   some data with them. The doctor can create some placeholder exchange data, encrypted only with his own key
-   *   through the {@link IccPatientXApi.initialiseExchangeDataToNewlyInvitedPatient} method, then create recovery data
+   *   through the {@link IccPatientXApi.forceInitialiseExchangeDataToNewlyInvitedPatient} method, then create recovery data
    *   for it and share the recovery key with the patient. The moment the patient logs in and creates his keypair he
    *   will use the {@link recoverExchangeData} method to "complete" the placeholder exchange data.
    *

--- a/icc-x-api/icc-recovery-x-api.ts
+++ b/icc-x-api/icc-recovery-x-api.ts
@@ -1,0 +1,88 @@
+import { KeyPair } from './crypto/RSA'
+
+export class IccRecoveryXApi {
+  /**
+   * Create recovery data for a keypair and stores it encrypted on the iCure server. This allows the user that created
+   * it to recover the keypair at a later time by just providing the string returned by this method to the
+   * {@link recoverKeyPair} method.
+   *
+   * You can also provide an expiration time for the recovery data. If you do so, the recovery data will be deleted
+   * automatically after ~{@link lifetimeSeconds} seconds. If you don't provide an expiration time, the recovery data
+   * will never expire.
+   *
+   * This could be used to:
+   * - Provide some sort of one-use "recovery codes" to the user, which he can use to recover his keypair if he loses
+   *   his device. In this case you should not put any expiration time on the recovery data.
+   * - Provide a way for the user to easily "copy" the key from one device to another. In this case you should put a
+   *   short expiration time on the recovery data (a few minutes), so that it will automatically be deleted if it is
+   *   not used after all.
+   *
+   * # Important
+   *
+   * A malicious user that can login as the creator of the recovery data or that can access directly the database
+   * containing the recovery data will be able to get the private key of the data owner from the recovery key returned
+   * by this method. The result must be kept secret, just like a private key.
+   *
+   * @param keyPair The keypair that will be available through this recovery data.
+   * @param lifetimeSeconds the amount of seconds the recovery data will be available. If not provided, the recovery
+   * data will be available until it is deleted.
+   * @return an hexadecimal string that is the `recoveryKey` which will allow the user to recover his keypair later or
+   * from another device. This value must be kept secret from other users. You can use this value with {@link recoverKeyPair}
+   */
+  async createKeyPairRecoveryData(keyPair: KeyPair<CryptoKey>, lifetimeSeconds?: number): Promise<string> {
+    throw 'TODO'
+  }
+
+  /**
+   * Recover a keypair from a recovery key created in the past by the {@link createKeyPairRecoveryData} method.
+   * @param recoveryKey the result of a past call to {@link createKeyPairRecoveryData}.
+   * @param autoDelete if true, the recovery data will be deleted from the server after it could be used successfully.
+   * This will prevent the recovery key from being used again.
+   * @return the keypair that was given as input to the call of {@link createKeyPairRecoveryData} which returned the
+   * provided {@link recoveryKey}.
+   */
+  async recoverKeyPair(recoveryKey: string, autoDelete: boolean): Promise<KeyPair<CryptoKey>> {
+    throw 'TODO'
+  }
+
+  /**
+   * Create recovery data that allows the delegate {@link delegateId} recover the content of exchange data from the
+   * current data owner to the delegate.
+   *
+   * This can be useful in the following situations:
+   * - A user lost access to his old keypair and is asking for access back to his data. This is similar to the
+   *   give-access-back mechanism, except that instead of having to verify the public key of the delegate as in the
+   *   give-access-back, the delegator has to provide the recovery key to the delegate: the delegator has to properly
+   *   identify the delegate instead of validating that the public key belongs to the delegate.
+   * - A patient is not yet registered in the system and therefore has no keypair, but the doctor wants to already share
+   *   some data with them. The doctor can create some placeholder exchange data, encrypted only with his own key
+   *   through the {@link IccPatientXApi.initialiseExchangeDataToNewlyInvitedPatient} method, then create recovery data
+   *   for it and share the recovery key with the patient. The moment the patient logs in and creates his keypair he
+   *   will use the {@link recoverExchangeData} method to "complete" the placeholder exchange data.
+   *
+   * @param delegateId id of the delegate that needs access to his exchange data from the current data owner. This can't
+   * be the id of the current data owner (you should instead recover the keypair).
+   * @param lifetimeSeconds the amount of seconds the recovery data will be available. If not provided, the recovery
+   * data will be available until it is deleted.
+   * @return an hexadecimal string that is the `recoveryKey` which will allow the delegate to gain access to the exchange data.
+   * This value must be kept secret from users other than the current data owner and the delegate.
+   * You can use this value with {@link recoverExchangeData}
+   */
+  async createExchangeDataRecoveryInfo(delegateId: string, lifetimeSeconds?: number): Promise<string> {
+    // TODO delegateId must not be current data owner
+    throw 'TODO'
+  }
+
+  /**
+   * Recover the content of exchange data from the delegator that created the recovery data at the provided.
+   * {@link recoveryKey} to the current delegate. This will enable the current user to access the exchange data with
+   * any of his private keys available on the device from which this method was called.
+   *
+   * @param recoveryKey the result of a call to {@link createExchangeDataRecoveryInfo} by a delegator.
+   */
+  async recoverExchangeData(recoveryKey: string): Promise<void> {
+    throw 'TODO'
+  }
+
+  // TODO delete methods (by recovery key, by recipient) + decide what to do if user tries to delete already deleted recovery data
+}

--- a/icc-x-api/icc-recovery-x-api.ts
+++ b/icc-x-api/icc-recovery-x-api.ts
@@ -167,6 +167,9 @@ export class IccRecoveryXApi {
         )
       }
     }
+    await this.baseRecoveryApi.deleteRecoveryData(await this.recoveryDataEncryption.recoveryKeyToId(recoveryKey)).catch((e) => {
+      console.warn(`Could not delete recovery data with id ${recoveryKey} after successful recovery: ${e}. Ignoring.`)
+    })
     return null
   }
 

--- a/icc-x-api/index.ts
+++ b/icc-x-api/index.ts
@@ -815,7 +815,7 @@ async function initialiseCryptoWithProvider(
       userEncryptionKeysManager,
       dataOwnerApi,
       cryptoPrimitives,
-      baseExchangeDataManager
+      exchangeDataManager
     ),
   }
 }

--- a/icc-x-api/index.ts
+++ b/icc-x-api/index.ts
@@ -95,6 +95,10 @@ import { DataOwnerTypeEnum } from '../icc-api/model/DataOwnerTypeEnum'
 import { DelegationsDeAnonymization } from './crypto/DelegationsDeAnonymization'
 import { JwtBridgedAuthService } from './auth/JwtBridgedAuthService'
 import { AuthSecretProvider, SmartAuthProvider } from './auth/SmartAuthProvider'
+import { KeyPairRecoverer } from './crypto/KeyPairRecoverer'
+import { IccRecoveryDataApi } from '../icc-api/api/internal/IccRecoveryDataApi'
+import { RecoveryDataEncryption } from './crypto/RecoveryDataEncryption'
+import { IccRecoveryXApi } from './icc-recovery-x-api'
 
 export * from './icc-accesslog-x-api'
 export * from './icc-bekmehr-x-api'
@@ -183,6 +187,7 @@ export interface Apis extends BasicApis {
   readonly tmpApi: IccTmpApi
   readonly topicApi: IccTopicXApi
   readonly roleApi: IccRoleApi
+  readonly recoveryApi: IccRecoveryXApi
 }
 
 /**
@@ -624,6 +629,7 @@ type CryptoInitialisationInfo = {
   maintenanceTaskApi: IccMaintenanceTaskXApi
   headers: { [headerName: string]: string }
   dataOwnerRequiresAnonymousDelegation: boolean
+  recoveryApi: IccRecoveryXApi
 }
 
 const REQUEST_AUTOFIX_ANONYMITY_HEADER = 'Icure-Request-Autofix-Anonymity'
@@ -663,19 +669,23 @@ async function initialiseCryptoWithProvider(
   const basePatientApi = new IccPatientApi(host, updatedHeaders, groupSpecificAuthenticationProvider, fetchImpl)
   const dataOwnerApi = new IccDataOwnerXApi(host, updatedHeaders, groupSpecificAuthenticationProvider, fetchImpl)
   const exchangeDataApi = new IccExchangeDataApi(host, updatedHeaders, groupSpecificAuthenticationProvider, fetchImpl)
+  const baseRecoveryDataApi = new IccRecoveryDataApi(host, updatedHeaders, groupSpecificAuthenticationProvider, fetchImpl)
   // Crypto initialisation
   const icureStorage = new IcureStorageFacade(params.keyStorage, params.storage, params.entryKeysFactory)
   const cryptoPrimitives = new CryptoPrimitives(crypto)
   const baseExchangeKeysManager = new BaseExchangeKeysManager(cryptoPrimitives, dataOwnerApi, healthcarePartyApi, basePatientApi, deviceApi)
   const baseExchangeDataManager = new BaseExchangeDataManager(exchangeDataApi, dataOwnerApi, cryptoPrimitives, dataOwnerRequiresAnonymousDelegation)
   const keyRecovery = new KeyRecovery(cryptoPrimitives, dataOwnerApi, baseExchangeKeysManager, baseExchangeDataManager)
+  const recoveryDataEncryption = new RecoveryDataEncryption(cryptoPrimitives, baseRecoveryDataApi)
+  const keyPairRecoverer = new KeyPairRecoverer(recoveryDataEncryption)
   const userEncryptionKeysManager = new UserEncryptionKeysManager(
     cryptoPrimitives,
     dataOwnerApi,
     icureStorage,
     keyRecovery,
     cryptoStrategies,
-    !params.disableParentKeysInitialisation
+    !params.disableParentKeysInitialisation,
+    keyPairRecoverer
   )
   const userSignatureKeysManager = new UserSignatureKeysManager(icureStorage, dataOwnerApi, cryptoPrimitives)
   const newKey = await userEncryptionKeysManager.initialiseKeys()
@@ -799,6 +809,14 @@ async function initialiseCryptoWithProvider(
     icureMaintenanceTaskApi,
     headers: updatedHeaders,
     dataOwnerRequiresAnonymousDelegation,
+    recoveryApi: new IccRecoveryXApi(
+      baseRecoveryDataApi,
+      recoveryDataEncryption,
+      userEncryptionKeysManager,
+      dataOwnerApi,
+      cryptoPrimitives,
+      baseExchangeDataManager
+    ),
   }
 }
 
@@ -820,6 +838,10 @@ class IcureApiImpl implements IcureApi {
   }
 
   private _authApi: IccAuthApi | undefined
+
+  get recoveryApi(): IccRecoveryXApi {
+    return this.cryptoInitInfos.recoveryApi
+  }
 
   get authApi(): IccAuthApi {
     return (

--- a/test/icc-x-api/crypto/exchange-data-manager-test.ts
+++ b/test/icc-x-api/crypto/exchange-data-manager-test.ts
@@ -207,8 +207,8 @@ describe('Exchange data manager - unit', async function () {
       await initialiseComponents(allowFullExchangeDataLoad)
       const sfk = primitives.randomUuid()
       const initialisedCount = exchangeDataApi.callCount
-      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk])
-      const retrievedCachedData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk])
+      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk], false)
+      const retrievedCachedData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk], false)
       exchangeDataApi.compareCallCountFromBaseline(initialisedCount, {
         createExchangeData: 1,
         // If we could fully preload we already know whether the exchange key already exists or not, otherwise we have to request from the api
@@ -238,7 +238,7 @@ describe('Exchange data manager - unit', async function () {
   it('should create encryption keys to self when none is available', async function () {
     async function doTest(allowFullExchangeDataLoad: boolean) {
       await initialiseComponents(allowFullExchangeDataLoad)
-      const createdData = await exchangeData.getOrCreateEncryptionDataTo(selfId, 'Contact', [primitives.randomUuid()])
+      const createdData = await exchangeData.getOrCreateEncryptionDataTo(selfId, 'Contact', [primitives.randomUuid()], false)
       expect(createdData.exchangeData.delegator).to.equal(selfId)
       expect(createdData.exchangeData.delegate).to.equal(selfId)
       expect(Object.keys(createdData.exchangeData.delegatorSignature)).to.have.length(1)
@@ -268,7 +268,7 @@ describe('Exchange data manager - unit', async function () {
         await dataOwnerApi.addPublicKeyForOwner(selfId, keyData.pair)
         await encryptionKeysManager.addOrUpdateKey(primitives, keyData.pair, false)
       }
-      const created = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [primitives.randomUuid()])
+      const created = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [primitives.randomUuid()], false)
       expect(
         setEquals(new Set(Object.keys(created.exchangeData.exchangeKey)), new Set(Object.keys(created.exchangeData.accessControlSecret))),
         'Keys used for encryption of exchange key and access control secret must be the same.'
@@ -300,10 +300,10 @@ describe('Exchange data manager - unit', async function () {
   it('should reuse existing exchange data for encryption when it can be verified', async function () {
     async function doTest(allowFullExchangeDataLoad: boolean) {
       await initialiseComponents(allowFullExchangeDataLoad)
-      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Patient', [])
+      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Patient', [], false)
       await exchangeData.clearOrRepopulateCache()
       const countAfterCacheClear = exchangeDataApi.callCount
-      const reloadedData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Patient', [])
+      const reloadedData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Patient', [], false)
       exchangeDataApi.compareCallCountFromBaseline(countAfterCacheClear, {
         createExchangeData: 0,
         getExchangeDataByDelegatorDelegate: allowFullExchangeDataLoad ? 0 : 1,
@@ -321,11 +321,11 @@ describe('Exchange data manager - unit', async function () {
     async function doTest(allowFullExchangeDataLoad: boolean) {
       await initialiseComponents(allowFullExchangeDataLoad)
       const sfk = primitives.randomUuid()
-      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk])
+      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk], false)
       signatureKeysManager.clearKeys()
       await exchangeData.clearOrRepopulateCache()
       const countAfterCacheClear = exchangeDataApi.callCount
-      const newData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk])
+      const newData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk], false)
       exchangeDataApi.compareCallCountFromBaseline(countAfterCacheClear, {
         createExchangeData: 1,
         getExchangeDataByDelegatorDelegate: allowFullExchangeDataLoad ? 0 : 1,
@@ -353,12 +353,12 @@ describe('Exchange data manager - unit', async function () {
     ) {
       await initialiseComponents(allowFullExchangeDataLoad)
       const sfk = primitives.randomUuid()
-      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk])
+      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk], false)
       // Tamper with exchange data
       await exchangeDataApi.modifyExchangeData(await tamper(createdData.exchangeData, selfKeypair, selfKeyFpV2))
       await exchangeData.clearOrRepopulateCache()
       const countAfterCacheClear = exchangeDataApi.callCount
-      const newData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk])
+      const newData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk], false)
       exchangeDataApi.compareCallCountFromBaseline(countAfterCacheClear, {
         createExchangeData: 1,
         getExchangeDataByDelegatorDelegate: allowFullExchangeDataLoad ? 0 : 1,
@@ -420,7 +420,7 @@ describe('Exchange data manager - unit', async function () {
     async function doTest(allowFullExchangeDataLoad: boolean) {
       await initialiseComponents(allowFullExchangeDataLoad)
       const sfk = primitives.randomUuid()
-      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk])
+      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk], false)
       // Tamper with exchange data
       await exchangeDataApi.modifyExchangeData({
         ...createdData.exchangeData,
@@ -428,8 +428,8 @@ describe('Exchange data manager - unit', async function () {
       })
       await exchangeData.clearOrRepopulateCache()
       const countAfterCacheClear = exchangeDataApi.callCount
-      const newDataToDelegate = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk])
-      const newDataToDelegate2 = await exchangeData.getOrCreateEncryptionDataTo(delegate2Id, 'Contact', [sfk])
+      const newDataToDelegate = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk], false)
+      const newDataToDelegate2 = await exchangeData.getOrCreateEncryptionDataTo(delegate2Id, 'Contact', [sfk], false)
       exchangeDataApi.compareCallCountFromBaseline(countAfterCacheClear, {
         createExchangeData: 2,
         getExchangeDataByDelegatorDelegate: allowFullExchangeDataLoad ? 0 : 2,
@@ -468,7 +468,7 @@ describe('Exchange data manager - unit', async function () {
     async function doTest(allowFullExchangeDataLoad: boolean) {
       await initialiseComponents(allowFullExchangeDataLoad)
       const sfk = primitives.randomUuid()
-      const createdData1 = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk])
+      const createdData1 = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Contact', [sfk], false)
       const createdData2 = await createDataFromRandomToSelf()
       signatureKeysManager.clearKeys()
       await exchangeData.clearOrRepopulateCache()
@@ -484,7 +484,7 @@ describe('Exchange data manager - unit', async function () {
       await initialiseComponents(allowFullExchangeDataLoad)
       const sfk1 = primitives.randomUuid()
       const sfk2 = primitives.randomUuid()
-      const createdData1 = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Patient', [])
+      const createdData1 = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Patient', [], false)
       const hashes1 = [await accessControlSecretUtils.secureDelegationKeyFor(createdData1.accessControlSecret, 'Patient', undefined)]
       const createdData2 = await createDataFromRandomToSelf()
       const hashes2 = await accessControlSecretUtils.secureDelegationKeysFor(createdData2.accessControlSecret, 'HealthElement', [sfk1, sfk2])
@@ -518,7 +518,7 @@ describe('Exchange data manager - unit', async function () {
   it('if data can not be decrypted the retrieval method should return undefined', async function () {
     async function doTest(allowFullExchangeDataLoad: boolean) {
       await initialiseComponents(allowFullExchangeDataLoad)
-      const createdBySelf = await exchangeData.getOrCreateEncryptionDataTo(selfId, 'Patient', [])
+      const createdBySelf = await exchangeData.getOrCreateEncryptionDataTo(selfId, 'Patient', [], false)
       const createdByOther = await createDataFromRandomToSelf()
       const newKey = await primitives.RSA.generateKeyPair('sha-256')
       await dataOwnerApi.addPublicKeyForOwner(selfId, newKey)
@@ -542,7 +542,7 @@ describe('Exchange data manager - unit', async function () {
   it('unverified keys should still be usable for decryption of data', async function () {
     async function doTest(allowFullExchangeDataLoad: boolean) {
       await initialiseComponents(allowFullExchangeDataLoad)
-      const createdBySelf = await exchangeData.getOrCreateEncryptionDataTo(selfId, 'Patient', [])
+      const createdBySelf = await exchangeData.getOrCreateEncryptionDataTo(selfId, 'Patient', [], false)
       const createdByOther = await createDataFromRandomToSelf()
       await encryptionKeysManager.addOrUpdateKey(primitives, selfKeypair, false)
       await exchangeData.clearOrRepopulateCache()
@@ -565,7 +565,7 @@ describe('Exchange data manager - unit', async function () {
         await checkDataEqual((await exchangeData.getCachedDecryptionDataKeyByAccessControlHash([hash], entityType, sfks))[hash], data)
       }
       if (data.exchangeData.delegator === selfId) {
-        await checkDataEqual(await exchangeData.getOrCreateEncryptionDataTo(data.exchangeData.delegate, entityType, sfks), data)
+        await checkDataEqual(await exchangeData.getOrCreateEncryptionDataTo(data.exchangeData.delegate, entityType, sfks, false), data)
       }
       await checkDataEqual(await exchangeData.getDecryptionDataKeyById(data.exchangeData.id!, entityType, sfks, true), data)
       exchangeDataApi.compareCallCountFromBaseline(apiCallsBaseline, {
@@ -584,7 +584,7 @@ describe('Exchange data manager - unit', async function () {
         expect(Object.keys(await exchangeData.getCachedDecryptionDataKeyByAccessControlHash([hash], entityType, sfks))).to.have.length(0)
       }
       if (data.exchangeData.delegator === selfId) {
-        await checkDataEqual(await exchangeData.getOrCreateEncryptionDataTo(data.exchangeData.delegate, entityType, sfks), data)
+        await checkDataEqual(await exchangeData.getOrCreateEncryptionDataTo(data.exchangeData.delegate, entityType, sfks, false), data)
         exchangeDataApi.compareCallCountFromBaseline(apiCallsBaseline, {
           getExchangeDataById: 0,
           createExchangeData: 0,
@@ -604,8 +604,8 @@ describe('Exchange data manager - unit', async function () {
       }
     }
 
-    const createdBySelf1 = await exchangeData.getOrCreateEncryptionDataTo(selfId, entityType, sfks)
-    const createdBySelf2 = await exchangeData.getOrCreateEncryptionDataTo(delegateId, entityType, sfks)
+    const createdBySelf1 = await exchangeData.getOrCreateEncryptionDataTo(selfId, entityType, sfks, false)
+    const createdBySelf2 = await exchangeData.getOrCreateEncryptionDataTo(delegateId, entityType, sfks, false)
     const createdByOther1 = await createDataFromRandomToSelf() // Not automatically cached: created by someone else
     const createdByOther2 = await createDataFromRandomToSelf() // Not automatically cached: created by someone else
     // noinspection DuplicatedCode
@@ -640,7 +640,7 @@ describe('Exchange data manager - unit', async function () {
 
   it('implementation with unlimited cache should preload all existing exchange data on creation', async function () {
     await initialiseComponents(true)
-    const createdBySelf = await exchangeData.getOrCreateEncryptionDataTo(selfId, 'Patient', [])
+    const createdBySelf = await exchangeData.getOrCreateEncryptionDataTo(selfId, 'Patient', [], false)
     const createdByOther = await createDataFromRandomToSelf()
     const recreatedExchangeData = await initialiseExchangeDataManagerForCurrentDataOwner(
       baseExchangeData,
@@ -677,8 +677,8 @@ describe('Exchange data manager - e2e', async function () {
   it('give access back should not invalidate existing and valid exchange data', async function () {
     const hcp1Details = await createNewHcpApi(env)
     const hcp2Details = await createNewHcpApi(env)
-    const ed1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp2Details.credentials.dataOwnerId, 'Patient', [])
-    const ed2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp1Details.credentials.dataOwnerId, 'Patient', [])
+    const ed1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp2Details.credentials.dataOwnerId, 'Patient', [], false)
+    const ed2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp1Details.credentials.dataOwnerId, 'Patient', [], false)
     await hcp1Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
     await hcp2Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
     const newKeyPair = await hcp1Details.api.cryptoApi.primitives.RSA.generateKeyPair('sha-256')
@@ -691,8 +691,18 @@ describe('Exchange data manager - e2e', async function () {
     await hcp1Details.api.cryptoApi.exchangeData.giveAccessBackTo(hcp2Details.credentials.dataOwnerId, exportedPub)
     await hcp1Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
     await hcp2Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
-    const updatedEd1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp2Details.credentials.dataOwnerId, 'Patient', [])
-    const updatedEd2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp1Details.credentials.dataOwnerId, 'Patient', [])
+    const updatedEd1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(
+      hcp2Details.credentials.dataOwnerId,
+      'Patient',
+      [],
+      false
+    )
+    const updatedEd2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(
+      hcp1Details.credentials.dataOwnerId,
+      'Patient',
+      [],
+      false
+    )
     expect(updatedEd1to2.exchangeData.id).to.equal(ed1to2.exchangeData.id)
     expect(Object.keys(updatedEd2to1.exchangeData.exchangeKey).length).to.be.greaterThan(Object.keys(ed2to1.exchangeData.exchangeKey).length)
     expect(Object.keys(updatedEd2to1.exchangeData.exchangeKey).length).to.equal(Object.keys(updatedEd2to1.exchangeData.accessControlSecret).length)
@@ -706,8 +716,8 @@ describe('Exchange data manager - e2e', async function () {
   it('invalid exchange data should not be re-validated by give access back', async function () {
     const hcp1Details = await createNewHcpApi(env)
     const hcp2Details = await createNewHcpApi(env)
-    const ed1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp2Details.credentials.dataOwnerId, 'Patient', [])
-    const ed2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp1Details.credentials.dataOwnerId, 'Patient', [])
+    const ed1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp2Details.credentials.dataOwnerId, 'Patient', [], false)
+    const ed2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp1Details.credentials.dataOwnerId, 'Patient', [], false)
     await hcp1Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
     await hcp2Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
     const exchangeDataApi = new IccExchangeDataApi(env.iCureUrl, {}, hcp1Details.api.authApi.authenticationProvider, fetch)
@@ -744,8 +754,18 @@ describe('Exchange data manager - e2e', async function () {
     await hcp1Details.api.cryptoApi.exchangeData.giveAccessBackTo(hcp2Details.credentials.dataOwnerId, exportedPub)
     await hcp1Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
     await hcp2Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
-    const updatedEd1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp2Details.credentials.dataOwnerId, 'Patient', [])
-    const updatedEd2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp1Details.credentials.dataOwnerId, 'Patient', [])
+    const updatedEd1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(
+      hcp2Details.credentials.dataOwnerId,
+      'Patient',
+      [],
+      false
+    )
+    const updatedEd2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(
+      hcp1Details.credentials.dataOwnerId,
+      'Patient',
+      [],
+      false
+    )
     expect(updatedEd1to2.exchangeData.id).to.not.equal(ed1to2.exchangeData.id)
     expect(updatedEd2to1.exchangeData.id).to.not.equal(ed2to1.exchangeData.id)
     const decData1to2 = await hcp1Details.api.cryptoApi.exchangeData.getDecryptionDataKeyById(ed1to2.exchangeData.id!, 'Patient', [], true)

--- a/test/icc-x-api/crypto/secure-delegations-manager-test.ts
+++ b/test/icc-x-api/crypto/secure-delegations-manager-test.ts
@@ -186,7 +186,7 @@ describe('Secure delegations manager', async function () {
       await initialiseComponents(false, false)
       const canonicalSfk = primitives.randomUuid()
       const aliasSfk = primitives.randomUuid()
-      const exchangeDataInfo = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Patient', [])
+      const exchangeDataInfo = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Patient', [], false)
       const canonicalKey = await accessControlSecretUtils.secureDelegationKeyFor(exchangeDataInfo.accessControlSecret, 'Patient', canonicalSfk)
       const aliasKey = await accessControlSecretUtils.secureDelegationKeyFor(exchangeDataInfo.accessControlSecret, 'Patient', aliasSfk)
       const existingSecretIds = [ua2hex(primitives.randomBytes(16))]
@@ -250,7 +250,7 @@ describe('Secure delegations manager', async function () {
   it('should return undefined for existing secure delegations if it contains all entries.', async function () {
     await initialiseComponents(false, false)
     const canonicalSfk = primitives.randomUuid()
-    const exchangeDataInfo = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Patient', [])
+    const exchangeDataInfo = await exchangeData.getOrCreateEncryptionDataTo(delegateId, 'Patient', [], false)
     const canonicalKey = await accessControlSecretUtils.secureDelegationKeyFor(exchangeDataInfo.accessControlSecret, 'Patient', canonicalSfk)
     const existingSecretIds = [ua2hex(primitives.randomBytes(16))]
     const existingEncryptionKeys: string[] = []

--- a/test/icc-x-api/icc-recovery-x-api.ts
+++ b/test/icc-x-api/icc-recovery-x-api.ts
@@ -1,0 +1,207 @@
+import { createNewHcpApi, getEnvironmentInitializer, getTempEmail, setLocalStorage, TestUtils } from '../utils/test_utils'
+import { before } from 'mocha'
+import { getEnvVariables, TestVars } from '@icure/test-setup/types'
+import { CryptoPrimitives, IcureApi, KeyPair, sleep } from '../../icc-x-api'
+import { randomUUID, webcrypto } from 'crypto'
+import { User } from '../../icc-api/model/User'
+import { assert, expect, use as chaiUse } from 'chai'
+import * as chaiAsPromised from 'chai-as-promised'
+import { TestKeyStorage, TestStorage } from '../utils/TestStorage'
+import { CryptoActorStubWithType } from '../../icc-api/model/CryptoActorStub'
+import { DataOwnerTypeEnum } from '../../icc-api/model/DataOwnerTypeEnum'
+import { DataOwnerWithType } from '../../icc-api/model/DataOwnerWithType'
+import { SecureDelegation } from '../../icc-api/model/SecureDelegation'
+import AccessLevelEnum = SecureDelegation.AccessLevelEnum
+import { RecoveryDataUseFailureReason } from '../../icc-x-api/icc-recovery-x-api'
+import { KeyPairRecoverer } from '../../icc-x-api/crypto/KeyPairRecoverer'
+import { delay } from 'lodash'
+
+chaiUse(chaiAsPromised)
+setLocalStorage(fetch)
+let env: TestVars
+
+describe('Recovery api use scenarios', () => {
+  before(async function () {
+    this.timeout(600000)
+    const initializer = await getEnvironmentInitializer()
+    env = await initializer.execute(getEnvVariables())
+  })
+
+  it('An hcp should be able to share data with an uninitialized patient data owner and the patient should be able to recover the exchange data with the provided recovery key.', async function () {
+    const hcp = await createNewHcpApi(env)
+    const patientId = randomUUID()
+    const patientMail = getTempEmail()
+    const patientPassword = randomUUID()
+    const patient = await hcp.api.patientApi.createPatientWithUser(
+      hcp.user,
+      await hcp.api.patientApi.newInstance(hcp.user, {
+        id: patientId,
+        firstName: 'John',
+        lastName: 'Doe',
+      })
+    )
+    const patientUser = await hcp.api.userApi.createUser(
+      new User({
+        id: randomUUID(),
+        login: patientMail,
+        passwordHash: patientPassword,
+        patientId: patientId,
+      })
+    )
+    const healthData = await hcp.api.healthcareElementApi.createHealthElementWithUser(
+      hcp.user,
+      await hcp.api.healthcareElementApi.newInstance(hcp.user, patient, {
+        descr: 'Health data',
+      })
+    )
+    await expect(hcp.api.healthcareElementApi.shareWith(patientId, healthData)).to.be.rejected
+    expect(await hcp.api.patientApi.forceInitialiseExchangeDataToNewlyInvitedPatient(patientId)).to.be.true
+    const recoveryKey = await hcp.api.recoveryApi.createExchangeDataRecoveryInfo(patientId)
+    const sharedHealthData = await hcp.api.healthcareElementApi.shareWith(patientId, healthData)
+    const patientApi = await IcureApi.initialise(
+      env.iCureUrl,
+      { username: patientMail, password: patientPassword },
+      {
+        dataOwnerRequiresAnonymousDelegation(dataOwner: CryptoActorStubWithType): boolean {
+          return dataOwner.type == DataOwnerTypeEnum.Patient
+        },
+        generateNewKeyForDataOwner(): Promise<boolean> {
+          return Promise.resolve(true)
+        },
+        recoverAndVerifySelfHierarchyKeys(
+          keysData: {
+            dataOwner: DataOwnerWithType
+            unknownKeys: string[]
+            unavailableKeys: string[]
+          }[]
+        ): Promise<{
+          [p: string]: { recoveredKeys: { [p: string]: KeyPair<CryptoKey> }; keyAuthenticity: { [p: string]: boolean } }
+        }> {
+          return Promise.resolve(Object.fromEntries(keysData.map((x) => [x.dataOwner.dataOwner.id, { recoveredKeys: {}, keyAuthenticity: {} }])))
+        },
+        verifyDelegatePublicKeys(_: any, publicKeys: string[]): Promise<string[]> {
+          return Promise.resolve(publicKeys)
+        },
+      },
+      webcrypto as any,
+      fetch,
+      {
+        storage: new TestStorage(),
+        keyStorage: new TestKeyStorage(),
+      }
+    )
+    await expect(patientApi.healthcareElementApi.getHealthElementWithUser(patientUser, sharedHealthData.id!)).to.be.rejected
+    expect(await patientApi.recoveryApi.recoverExchangeData(recoveryKey + 'aa')).to.equal(RecoveryDataUseFailureReason.Missing) // User put in the wrong key
+    expect(await patientApi.recoveryApi.recoverExchangeData(recoveryKey)).to.be.null
+    expect(await patientApi.recoveryApi.recoverExchangeData(recoveryKey)).to.equal(RecoveryDataUseFailureReason.Missing) // After use it is automatically deleted
+    expect(await patientApi.healthcareElementApi.getHealthElementWithUser(patientUser, sharedHealthData.id!)).to.be.deep.equal(sharedHealthData)
+    await hcp.api.cryptoApi.forceReload()
+    const healthData2 = await hcp.api.healthcareElementApi.createHealthElementWithUser(
+      hcp.user,
+      await hcp.api.healthcareElementApi.newInstance(
+        hcp.user,
+        patient,
+        {
+          descr: 'Health data 2',
+        },
+        {
+          additionalDelegates: { [patientId]: AccessLevelEnum.WRITE },
+        }
+      )
+    )
+    expect(await patientApi.healthcareElementApi.getHealthElementWithUser(patientUser, healthData2.id!)).to.be.deep.equal(healthData2)
+    expect(await hcp.api.cryptoApi.exchangeData.base.getExchangeDataByDelegatorDelegatePair(hcp.credentials.dataOwnerId, patientId)).to.have.length(1)
+  })
+
+  it('A user should be able to create keypair recovery data and use the recovery key to get back the keys.', async function () {
+    const hcp = await createNewHcpApi(env)
+    const patient = await hcp.api.patientApi.createPatientWithUser(
+      hcp.user,
+      await hcp.api.patientApi.newInstance(hcp.user, {
+        firstName: 'John',
+        lastName: 'Doe',
+        note: 'Encrypted content',
+      })
+    )
+    expect(patient.note).to.equal('Encrypted content')
+    const recoveryKey = await hcp.api.recoveryApi.createRecoveryInfoForAvailableKeyPairs()
+    let recoverAndVerifiedCalled = false
+    const recoveredApi = await IcureApi.initialise(
+      env.iCureUrl,
+      { username: hcp.credentials.user, password: hcp.credentials.password },
+      {
+        dataOwnerRequiresAnonymousDelegation(dataOwner: CryptoActorStubWithType): boolean {
+          return dataOwner.type == DataOwnerTypeEnum.Patient
+        },
+        generateNewKeyForDataOwner(): Promise<boolean> {
+          return Promise.resolve(false)
+        },
+        async recoverAndVerifySelfHierarchyKeys(
+          keysData: {
+            dataOwner: DataOwnerWithType
+            unknownKeys: string[]
+            unavailableKeys: string[]
+          }[],
+          _: any,
+          keyRecoverer: KeyPairRecoverer
+        ): Promise<{
+          [p: string]: { recoveredKeys: { [p: string]: KeyPair<CryptoKey> }; keyAuthenticity: { [p: string]: boolean } }
+        }> {
+          recoverAndVerifiedCalled = true
+          const recovered = await keyRecoverer.recoverWithRecoveryKey(recoveryKey, true)
+          if ('success' in recovered) {
+            expect(Object.entries(recovered.success)).to.have.length(1)
+            const recoveredForSelf = recovered.success[hcp.credentials.dataOwnerId]
+            expect(Object.entries(recoveredForSelf)).to.have.length(1)
+            expect(await keyRecoverer.recoverWithRecoveryKey(recoveryKey, true)).to.deep.equal({ failure: RecoveryDataUseFailureReason.Missing })
+            const res: {
+              [p: string]: { recoveredKeys: { [p: string]: KeyPair<CryptoKey> }; keyAuthenticity: { [p: string]: boolean } }
+            } = {}
+            for (const keyData of keysData) {
+              if (keyData.dataOwner.dataOwner.id == hcp.credentials.dataOwnerId) {
+                res[keyData.dataOwner.dataOwner.id] = {
+                  recoveredKeys: recoveredForSelf,
+                  keyAuthenticity: {},
+                }
+              } else {
+                res[keyData.dataOwner.dataOwner.id!] = {
+                  recoveredKeys: {},
+                  keyAuthenticity: {},
+                }
+              }
+            }
+            return res
+          } else {
+            assert.fail('Could not recover keys with recovery key')
+          }
+        },
+        verifyDelegatePublicKeys(_: any, publicKeys: string[]): Promise<string[]> {
+          return Promise.resolve(publicKeys)
+        },
+      },
+      webcrypto as any,
+      fetch,
+      {
+        storage: new TestStorage(),
+        keyStorage: new TestKeyStorage(),
+      }
+    )
+    expect(recoverAndVerifiedCalled).to.be.true
+    expect(recoveredApi.dataOwnerApi.getHexPublicKeysOf(await recoveredApi.healthcarePartyApi.getCurrentHealthcareParty())).to.have.length(1)
+    expect(await recoveredApi.patientApi.getPatientWithUser(hcp.user, patient.id!)).to.be.deep.equal(patient)
+  })
+
+  it('Recovery data should expire after the lifetime has elapsed', async function () {
+    const hcp = await createNewHcpApi(env)
+    const recoveryKey = await hcp.api.recoveryApi.createRecoveryInfoForAvailableKeyPairs({ lifetimeSeconds: 5 })
+    await sleep(1000)
+    const recovered1 = await hcp.api.recoveryApi.recoverKeyPairs(recoveryKey, false)
+    expect(recovered1).to.have.keys('success')
+    await sleep(1000)
+    const recovered2 = await hcp.api.recoveryApi.recoverKeyPairs(recoveryKey, false)
+    expect(recovered2).to.have.keys('success')
+    await sleep(3000)
+    const recovered3 = await hcp.api.recoveryApi.recoverKeyPairs(recoveryKey, false)
+    expect(recovered3).to.deep.equal({ failure: RecoveryDataUseFailureReason.Missing })
+  })
+})

--- a/test/utils/FakeEncryptionKeysManager.ts
+++ b/test/utils/FakeEncryptionKeysManager.ts
@@ -8,7 +8,7 @@ import { fingerprintV1 } from '../../icc-x-api/crypto/utils'
 
 export class FakeEncryptionKeysManager extends UserEncryptionKeysManager {
   constructor(private readonly keys: { [fingerprint: string]: { pair: KeyPair<CryptoKey>; verified: boolean } }) {
-    super(null as any, null as any, null as any, null as any, null as any, null as any)
+    super(null as any, null as any, null as any, null as any, null as any, null as any, null as any)
   }
 
   static async create(


### PR DESCRIPTION
Add support for:
- Sharing data with a user that did not yet initialize a key pair
- Simplified key pair recovery procedure
- Alternative 'give access back' process using one-time recovery codes