### PR TITLE
Keyless api mode

### DIFF
--- a/icc-api/model/internal/ExchangeData.ts
+++ b/icc-api/model/internal/ExchangeData.ts
@@ -3,15 +3,7 @@
  */
 export class ExchangeData {
   constructor(json: JSON | any) {
-    if (
-      !json.delegator ||
-      !json.delegate ||
-      !json.exchangeKey ||
-      !json.accessControlSecret ||
-      !json.sharedSignatureKey ||
-      !json.sharedSignature ||
-      !json.delegatorSignature
-    )
+    if (!json.delegator || !json.delegate || !json.exchangeKey || !json.accessControlSecret || !json.sharedSignatureKey || !json.sharedSignature)
       throw new Error(`Exchange data json is missing required properties.\n${JSON.stringify(json, undefined, 2)}`)
     Object.assign(this as ExchangeData, json)
   }

--- a/icc-api/model/internal/ExchangeData.ts
+++ b/icc-api/model/internal/ExchangeData.ts
@@ -69,7 +69,7 @@ export class ExchangeData {
    * sign it with his own private key.
    * This field will contain the signature by fingerprint of the public key to use for verification.
    */
-  delegatorSignature!: { [keyPairFingerprint: string]: string }
+  delegatorSignature?: { [keyPairFingerprint: string]: string }
   /**
    * Base 64 signature of the exchange data, to ensure it was not tampered by third parties. This signature validates:
    * - The (decrypted) exchange key

--- a/icc-x-api/crypto/BaseExchangeDataManager.ts
+++ b/icc-x-api/crypto/BaseExchangeDataManager.ts
@@ -263,9 +263,10 @@ export class BaseExchangeDataManager {
     exchangeData: ExchangeData
     exchangeKey: CryptoKey
     accessControlSecret: string
+    sharedSignatureKey: CryptoKey
   }> {
-    if (!Object.keys(signatureKeys).length || !Object.keys(encryptionKeys).length) {
-      throw new Error('Must specify at least one signature key and ')
+    if (!Object.keys(encryptionKeys).length) {
+      throw new Error('Must specify at least one encryption key ')
     }
     const exchangeKey = await this.generateExchangeKey()
     const accessControlSecret = await this.generateAccessControlSecret()
@@ -302,6 +303,7 @@ export class BaseExchangeDataManager {
       exchangeData: await this.api.createExchangeData(exchangeData),
       exchangeKey: exchangeKey.key,
       accessControlSecret: accessControlSecret.secret,
+      sharedSignatureKey: sharedSignatureKey.key,
     }
   }
 
@@ -350,29 +352,39 @@ export class BaseExchangeDataManager {
     const rawAccessControlSecret = await this.tryDecrypt(exchangeData.accessControlSecret, decryptionKeys)
     const rawSharedSignatureKey = await this.tryDecrypt(exchangeData.sharedSignatureKey, decryptionKeys)
     if (!rawExchangeKey || !rawAccessControlSecret || !rawSharedSignatureKey) return undefined
-    return await this.updateExchangeDataWithRawDecryptedContent(
-      exchangeData,
-      newEncryptionKeys,
-      rawExchangeKey,
-      rawAccessControlSecret,
-      rawSharedSignatureKey
-    )
+    return await this.updateExchangeDataWithRawDecryptedContent({
+      exchangeData: exchangeData,
+      newEncryptionKeys: newEncryptionKeys,
+      rawExchangeKey: rawExchangeKey,
+      rawAccessControlSecret: rawAccessControlSecret,
+      rawSharedSignatureKey: rawSharedSignatureKey,
+      newDelegatorSignatureKeys: {},
+    })
   }
 
   /**
    * Same as [tryUpdateExchangeData] but the decrypted content is already provided.
    */
-  async updateExchangeDataWithRawDecryptedContent(
-    exchangeData: ExchangeData,
-    newEncryptionKeys: { [keyPairFingerprint: string]: CryptoKey },
-    rawExchangeKey: ArrayBuffer,
-    rawAccessControlSecret: ArrayBuffer,
+  async updateExchangeDataWithRawDecryptedContent({
+    exchangeData,
+    newEncryptionKeys,
+    rawExchangeKey,
+    rawAccessControlSecret,
+    rawSharedSignatureKey,
+    newDelegatorSignatureKeys,
+  }: {
+    exchangeData: ExchangeData
+    newEncryptionKeys: { [fp: string]: CryptoKey }
+    newDelegatorSignatureKeys: { [keyPairFingerprint: string]: CryptoKey }
+    rawExchangeKey: ArrayBuffer
+    rawAccessControlSecret: ArrayBuffer
     rawSharedSignatureKey: ArrayBuffer
-  ): Promise<{
+  }): Promise<{
     exchangeData: ExchangeData
     exchangeKey: CryptoKey
     accessControlSecret: string
   }> {
+    const self = await this.dataOwnerApi.getCurrentDataOwnerId()
     const exchangeKey = await this.importExchangeKey(new Uint8Array(rawExchangeKey))
     const accessControlSecret = await this.importAccessControlSecret(new Uint8Array(rawAccessControlSecret))
     const sharedSignatureKey = await this.importSharedSignatureKey(new Uint8Array(rawSharedSignatureKey))
@@ -382,7 +394,10 @@ export class BaseExchangeDataManager {
     const missingEntries = Object.keys(newEncryptionKeys).filter(
       (fp) => !existingAcsEntries.has(fp) || !existingExchangeKeyEntries.has(fp) || !existingSharedSignatureKeyEntries.has(fp)
     )
-    if (!missingEntries.length) return { exchangeData, exchangeKey, accessControlSecret }
+    const existingDelegatorSignatureEntries = new Set(Object.keys(exchangeData.delegatorSignature ?? {}))
+    const missingDelegatorSignatureEntries =
+      exchangeData.delegator == self ? Object.keys(newDelegatorSignatureKeys).filter((fp) => !existingDelegatorSignatureEntries.has(fp)) : []
+    if (!missingEntries.length && !missingDelegatorSignatureEntries.length) return { exchangeData, exchangeKey, accessControlSecret }
     const encryptionKeysForMissingEntries = missingEntries.reduce((obj, fp) => {
       obj[fp] = newEncryptionKeys[fp]
       return obj
@@ -421,6 +436,20 @@ export class BaseExchangeDataManager {
         }),
         sharedSignatureKey
       )
+    }
+    if (missingDelegatorSignatureEntries.length > 0) {
+      const bytesToSign = await this.bytesToSignForDelegatorSignature({ sharedSignatureKey })
+      const newSigned = await this.signDataWithDelegatorKeys(
+        bytesToSign,
+        missingDelegatorSignatureEntries.reduce((obj, fp) => {
+          obj[fp] = newDelegatorSignatureKeys[fp]
+          return obj
+        }, {} as { [keyPairFingerprint: string]: CryptoKey })
+      )
+      updatedExchangeData.delegatorSignature = {
+        ...updatedExchangeData.delegatorSignature,
+        ...newSigned,
+      }
     }
     return { exchangeData: await this.api.modifyExchangeData(new ExchangeData(updatedExchangeData)), exchangeKey, accessControlSecret }
   }
@@ -461,11 +490,11 @@ export class BaseExchangeDataManager {
     }
   }
 
-  private async importExchangeKey(decryptedBytes: ArrayBuffer): Promise<CryptoKey> {
+  async importExchangeKey(decryptedBytes: ArrayBuffer): Promise<CryptoKey> {
     return await this.primitives.AES.importKey('raw', decryptedBytes)
   }
 
-  private async exportExchangeKey(key: CryptoKey): Promise<ArrayBuffer> {
+  async exportExchangeKey(key: CryptoKey): Promise<ArrayBuffer> {
     return await this.primitives.AES.exportKey(key, 'raw')
   }
 
@@ -477,11 +506,11 @@ export class BaseExchangeDataManager {
     return { key, rawBytes: await this.primitives.HMAC.exportKey(key) }
   }
 
-  private async importSharedSignatureKey(decryptedBytes: ArrayBuffer): Promise<CryptoKey> {
+  async importSharedSignatureKey(decryptedBytes: ArrayBuffer): Promise<CryptoKey> {
     return await this.primitives.HMAC.importKey(decryptedBytes)
   }
 
-  private async exportSharedSignatureKey(key: CryptoKey): Promise<ArrayBuffer> {
+  async exportSharedSignatureKey(key: CryptoKey): Promise<ArrayBuffer> {
     return await this.primitives.HMAC.exportKey(key)
   }
 
@@ -497,11 +526,11 @@ export class BaseExchangeDataManager {
     }
   }
 
-  private importAccessControlSecret(decryptedBytes: ArrayBuffer): Promise<string> {
+  importAccessControlSecret(decryptedBytes: ArrayBuffer): Promise<string> {
     return Promise.resolve(ua2hex(decryptedBytes))
   }
 
-  private exportAccessControlSecret(secret: string): Promise<ArrayBuffer> {
+  exportAccessControlSecret(secret: string): Promise<ArrayBuffer> {
     return Promise.resolve(hex2ua(secret))
   }
 
@@ -545,7 +574,7 @@ export class BaseExchangeDataManager {
       sharedSignatureKey: decryptedSharedSignatureKey,
     })
     const keysByV2Fp = Object.fromEntries(Object.entries(verificationKeys).map(([fp, key]): [string, CryptoKey] => [fingerprintV1toV2(fp), key]))
-    for (const [fp, signature] of Object.entries(exchangeData.delegatorSignature)) {
+    for (const [fp, signature] of Object.entries(exchangeData.delegatorSignature ?? {})) {
       const verificationKey = keysByV2Fp[fp]
       if (
         verificationKey &&

--- a/icc-x-api/crypto/CryptoStrategies.ts
+++ b/icc-x-api/crypto/CryptoStrategies.ts
@@ -67,8 +67,9 @@ export interface CryptoStrategies {
    * - If this method returns a key pair the crypto api loads the key pair and considers it as a device key.
    * - If this method returns false the initialisation will fail with a predefined error.
    * - If this method throws an error the initialisation will propagate the error.
+   * - If this method return the string "keyless" the api will be initialized in keyless mode.
    */
-  generateNewKeyForDataOwner(self: DataOwnerWithType, cryptoPrimitives: CryptoPrimitives): Promise<KeyPair<CryptoKey> | boolean>
+  generateNewKeyForDataOwner(self: DataOwnerWithType, cryptoPrimitives: CryptoPrimitives): Promise<KeyPair<CryptoKey> | boolean | 'keyless'>
 
   /**
    * Verifies if the public keys of a data owner which will be the delegate of a new exchange key do actually belong to the person the data owner

--- a/icc-x-api/crypto/DelegationsDeAnonymization.ts
+++ b/icc-x-api/crypto/DelegationsDeAnonymization.ts
@@ -267,7 +267,8 @@ export class DelegationsDeAnonymization {
       undefined,
       undefined,
       true,
-      Object.fromEntries(initialDelegates.map((x) => [x, AccessLevelEnum.READ]))
+      Object.fromEntries(initialDelegates.map((x) => [x, AccessLevelEnum.READ])),
+      undefined
     )
     const encryptedKeyMap = (
       await this.xapis.tryEncryptEntities(

--- a/icc-x-api/crypto/ExchangeDataManager.ts
+++ b/icc-x-api/crypto/ExchangeDataManager.ts
@@ -11,6 +11,7 @@ import { CryptoActorStubWithType } from '../../icc-api/model/CryptoActorStub'
 import { ShaVersion } from './RSA'
 import { Mutex } from 'async-mutex'
 import { SimpleLruCache } from '../utils/simple-lru-cache'
+import * as console from 'node:console'
 
 export type ExchangeDataManagerOptionalParameters = {
   // Only for not fully cached implementation (data owner can't request all his exchange data), amount of exchange data which can be cached
@@ -64,6 +65,7 @@ type CachedExchangeData = {
     accessControlSecret: string
     exchangeKey: CryptoKey
     verified: boolean
+    sharedSignatureKey: CryptoKey
   }
 }
 
@@ -87,14 +89,20 @@ export interface ExchangeDataManager {
    * Gets any existing and verified exchange data from the current data owner to the provided delegate or creates new data if no verified data is
    * available, then caches it.
    * @param delegateId the id of the delegate.
-   * @param allowCreationWithoutDelegateKey if true, when creating new exchange data, even if no verified key is available for the delegate the method
+   * @param options
+   * - allowCreationWithoutDelegatorKey if true, when creating new exchange data, even if no verified key is available for the delegator the method
+   * will create the new exchange data anyway (will not be usable by the delegate without additional steps).
+   * - allowCreationWithoutDelegateKey if true, when creating new exchange data, even if no verified key is available for the delegate the method
    * will create the new exchange data anyway (will not be usable by the delegate without additional steps).
    * @return the access control secret and key of the data to use for encryption.
    */
   getOrCreateEncryptionDataTo(
     delegateId: string,
-    allowCreationWithoutDelegateKey: boolean
-  ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey }>
+    options?: {
+      allowCreationWithoutDelegatorKey?: boolean
+      allowCreationWithoutDelegateKey?: boolean
+    }
+  ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey; sharedSignatureKey: CryptoKey }>
 
   /**
    * Retrieve the cached decrypted exchange data key associated with any of the provided hashes/entry keys of secure delegations.
@@ -138,6 +146,26 @@ export interface ExchangeDataManager {
    * data owner, which can be used to search for data.
    */
   getAllDelegationKeys(entityType: EntityWithDelegationTypeName): Promise<string[] | undefined>
+
+  /**
+   * Injects already decrypted exchange data, allowing it to be used by the sdk.
+   * @param exchangeDataDetails the exchange data to inject, with the decrypted content and verified status.
+   * Note that the SDK won't verify that the provided decrypted content actually matches what is stored in the exchange
+   * data.
+   * @param reEncryptWithOwnKeys if true all the provided exchange data that is not encrypted with any of the self
+   * verified keys of the user will be re-encrypted with them. In case the user is also the delegator and the data is
+   * verified the delegator signature will be updated.
+   */
+  injectDecryptedExchangeData(
+    exchangeDataDetails: {
+      exchangeDataId: string
+      accessControlSecret: ArrayBuffer
+      exchangeKey: ArrayBuffer
+      sharedSignatureKey: ArrayBuffer
+      verified: boolean
+    }[],
+    reEncryptWithOwnKeys: boolean
+  ): Promise<void>
 }
 
 abstract class AbstractExchangeDataManager implements ExchangeDataManager {
@@ -156,6 +184,7 @@ abstract class AbstractExchangeDataManager implements ExchangeDataManager {
         accessControlSecret: string
         exchangeKey: CryptoKey
         verified: boolean
+        sharedSignatureKey: CryptoKey
       }
     | undefined
   > {
@@ -174,6 +203,7 @@ abstract class AbstractExchangeDataManager implements ExchangeDataManager {
     return {
       accessControlSecret: decryptedAccessControlSecret,
       exchangeKey: decryptedExchangeKey,
+      sharedSignatureKey: decryptedSharedSignatureKey,
       verified: await this.base.verifyExchangeData(
         {
           exchangeData: data,
@@ -191,11 +221,16 @@ abstract class AbstractExchangeDataManager implements ExchangeDataManager {
     delegateId: string,
     options: {
       newDataId?: string
+      allowNoDelegatorKeys?: boolean
       allowNoDelegateKeys?: boolean
     }
-  ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey }> {
+  ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey; sharedSignatureKey: CryptoKey }> {
+    if (options.allowNoDelegateKeys && options.allowNoDelegatorKeys)
+      throw new Error('Illegal arguments: allow no delegator and no delegate keys should never both be true')
     const encryptionKeys: { [fp: string]: CryptoKey } = {}
     const selfVerifiedKeys = this.encryptionKeys.getSelfVerifiedKeys()
+    if (selfVerifiedKeys.length <= 0 && !options.allowNoDelegatorKeys)
+      throw new Error('If the sdk is initialized in keyless mode you must create exchange data explicitly')
     selfVerifiedKeys.forEach(({ fingerprint, pair }) => {
       encryptionKeys[fingerprint] = pair.publicKey
     })
@@ -242,6 +277,7 @@ abstract class AbstractExchangeDataManager implements ExchangeDataManager {
       exchangeData: newData.exchangeData,
       accessControlSecret: newData.accessControlSecret,
       exchangeKey: newData.exchangeKey,
+      sharedSignatureKey: newData.sharedSignatureKey,
     }
   }
 
@@ -276,8 +312,11 @@ abstract class AbstractExchangeDataManager implements ExchangeDataManager {
 
   getOrCreateEncryptionDataTo(
     delegateId: string,
-    allowCreationWithoutDelegateKey: boolean
-  ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey }> {
+    options?: {
+      allowCreationWithoutDelegatorKey?: boolean
+      allowCreationWithoutDelegateKey?: boolean
+    }
+  ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey; sharedSignatureKey: CryptoKey }> {
     throw new Error('Implemented by concrete class')
   }
 
@@ -307,6 +346,74 @@ abstract class AbstractExchangeDataManager implements ExchangeDataManager {
   getAllDelegationKeys(entityType: EntityWithDelegationTypeName): Promise<string[] | undefined> {
     throw new Error('Implemented by concrete class')
   }
+
+  async injectDecryptedExchangeData(
+    exchangeDataDetails: {
+      exchangeDataId: string
+      accessControlSecret: ArrayBuffer
+      exchangeKey: ArrayBuffer
+      sharedSignatureKey: ArrayBuffer
+      verified: boolean
+    }[],
+    reEncryptWithOwnKeys: boolean
+  ): Promise<void> {
+    const self = await this.dataOwnerApi.getCurrentDataOwnerId()
+    const retrievedExchangeData = await this.base.getExchangeDataByIds(exchangeDataDetails.map((x) => x.exchangeDataId))
+    if (retrievedExchangeData.some((x) => x.delegator != self && x.delegate != self))
+      throw new Error('Should only inject exchange date from/to the current user')
+    const exchangeDataById: { [id: string]: ExchangeData } = {}
+    retrievedExchangeData.forEach((x) => (exchangeDataById[x.id!] = x))
+    if (reEncryptWithOwnKeys) {
+      const selfVerifiedKeys = this.encryptionKeys.getSelfVerifiedKeys()
+      if (selfVerifiedKeys.length <= 0) throw new Error("Can't re-encrypt injected exchange data with own keys if in keyless mode")
+      const encryptionKeys: { [fp: string]: CryptoKey } = {}
+      selfVerifiedKeys.forEach(({ fingerprint, pair }) => {
+        encryptionKeys[fingerprint] = pair.publicKey
+      })
+      const signatureKeys = Object.fromEntries(selfVerifiedKeys.map((x): [string, CryptoKey] => [x.fingerprint, x.pair.privateKey]))
+      for (const details of exchangeDataDetails) {
+        const exchangeData = exchangeDataById[details.exchangeDataId]
+        if (exchangeData != null)
+          await this.base.updateExchangeDataWithRawDecryptedContent({
+            exchangeData,
+            newEncryptionKeys: encryptionKeys,
+            newDelegatorSignatureKeys: exchangeData.delegator == self && details.verified ? signatureKeys : {},
+            rawExchangeKey: details.exchangeKey,
+            rawAccessControlSecret: details.accessControlSecret,
+            rawSharedSignatureKey: details.sharedSignatureKey,
+          })
+      }
+    }
+    const importedDetails: {
+      exchangeData: ExchangeData
+      accessControlSecret: string
+      exchangeKey: CryptoKey
+      sharedSignatureKey: CryptoKey
+      verified: boolean
+    }[] = []
+    for (const details of exchangeDataDetails) {
+      const exchangeData = exchangeDataById[details.exchangeDataId]
+      if (exchangeData != undefined)
+        importedDetails.push({
+          exchangeData: exchangeData,
+          accessControlSecret: await this.base.importAccessControlSecret(details.accessControlSecret),
+          exchangeKey: await this.base.importExchangeKey(details.exchangeKey),
+          sharedSignatureKey: await this.base.importSharedSignatureKey(details.sharedSignatureKey),
+          verified: details.verified,
+        })
+    }
+    await this.cacheInjectedExchangeData(importedDetails)
+  }
+
+  protected abstract cacheInjectedExchangeData(
+    exchangeDataDetails: {
+      exchangeData: ExchangeData
+      accessControlSecret: string
+      exchangeKey: CryptoKey
+      sharedSignatureKey: CryptoKey
+      verified: boolean
+    }[]
+  ): Promise<void>
 }
 
 class FullyCachedExchangeDataManager extends AbstractExchangeDataManager {
@@ -352,7 +459,7 @@ class FullyCachedExchangeDataManager extends AbstractExchangeDataManager {
 
   private async getCachedEncryptionDataTo(
     delegateId: string
-  ): Promise<{ exchangeKey: CryptoKey; accessControlSecret: string; exchangeData: ExchangeData } | undefined> {
+  ): Promise<{ exchangeKey: CryptoKey; accessControlSecret: string; exchangeData: ExchangeData; sharedSignatureKey: CryptoKey } | undefined> {
     const caches = await this.caches
     const dataId = caches.delegateToVerifiedEncryptionDataId[delegateId]
     const cached = dataId ? caches.dataById[dataId] : undefined
@@ -361,6 +468,7 @@ class FullyCachedExchangeDataManager extends AbstractExchangeDataManager {
         exchangeData: cached.exchangeData,
         accessControlSecret: cached.decrypted.accessControlSecret,
         exchangeKey: cached.decrypted.exchangeKey,
+        sharedSignatureKey: cached.decrypted.sharedSignatureKey,
       }
     } else {
       return undefined
@@ -369,18 +477,25 @@ class FullyCachedExchangeDataManager extends AbstractExchangeDataManager {
 
   async getOrCreateEncryptionDataTo(
     delegateId: string,
-    allowCreationWithoutDelegateKey: boolean
-  ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey }> {
+    options?: {
+      allowCreationWithoutDelegatorKey?: boolean
+      allowCreationWithoutDelegateKey?: boolean
+    }
+  ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey; sharedSignatureKey: CryptoKey }> {
     const initialCached = await this.getCachedEncryptionDataTo(delegateId)
     if (initialCached) return initialCached
     const release = await this.createExchangeDataMutex.acquire()
     try {
       const cachedAfterMutex = await this.getCachedEncryptionDataTo(delegateId)
       if (cachedAfterMutex) return cachedAfterMutex
-      const created = await this.createNewExchangeData(delegateId, { allowNoDelegateKeys: allowCreationWithoutDelegateKey })
+      const created = await this.createNewExchangeData(delegateId, {
+        allowNoDelegateKeys: options?.allowCreationWithoutDelegateKey ?? false,
+        allowNoDelegatorKeys: options?.allowCreationWithoutDelegatorKey ?? false,
+      })
       this.cacheData(created.exchangeData, true, {
         accessControlSecret: created.accessControlSecret,
         exchangeKey: created.exchangeKey,
+        sharedSignatureKey: created.sharedSignatureKey,
         verified: true,
       })
       return created
@@ -423,7 +538,7 @@ class FullyCachedExchangeDataManager extends AbstractExchangeDataManager {
   private cacheData(
     exchangeData: ExchangeData,
     isNewData: boolean,
-    decrypted: { accessControlSecret: string; exchangeKey: CryptoKey; verified: boolean } | undefined
+    decrypted: { accessControlSecret: string; exchangeKey: CryptoKey; verified: boolean; sharedSignatureKey: CryptoKey } | undefined
   ): void {
     this.caches = this.caches.then(async (caches) => {
       caches.dataById[exchangeData.id!] = { exchangeData, decrypted }
@@ -487,6 +602,25 @@ class FullyCachedExchangeDataManager extends AbstractExchangeDataManager {
       res.push(await this.accessControlSecret.secureDelegationKeyFor(accessControlSecret, entityType))
     }
     return res
+  }
+
+  protected async cacheInjectedExchangeData(
+    exchangeDataDetails: {
+      exchangeData: ExchangeData
+      accessControlSecret: string
+      exchangeKey: CryptoKey
+      sharedSignatureKey: CryptoKey
+      verified: boolean
+    }[]
+  ): Promise<void> {
+    for (const details of exchangeDataDetails) {
+      this.cacheData(details.exchangeData, true, {
+        accessControlSecret: details.accessControlSecret,
+        exchangeKey: details.exchangeKey,
+        sharedSignatureKey: details.sharedSignatureKey,
+        verified: details.verified,
+      })
+    }
   }
 }
 
@@ -604,8 +738,11 @@ class LimitedLruCacheExchangeDataManager extends AbstractExchangeDataManager {
 
   async getOrCreateEncryptionDataTo(
     delegateId: string,
-    allowCreationWithoutDelegateKey: boolean
-  ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey }> {
+    options?: {
+      allowCreationWithoutDelegatorKey?: boolean
+      allowCreationWithoutDelegateKey?: boolean
+    }
+  ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey; sharedSignatureKey: CryptoKey }> {
     const release = await this.cacheMutex.acquire()
     try {
       let existingId = this.delegateToVerifiedEncryptionDataId.get(delegateId)
@@ -621,11 +758,13 @@ class LimitedLruCacheExchangeDataManager extends AbstractExchangeDataManager {
             exchangeData: cached.exchangeData,
             exchangeKey: cached.decrypted.exchangeKey,
             accessControlSecret: cached.decrypted.accessControlSecret,
+            sharedSignatureKey: cached.decrypted.sharedSignatureKey,
           }
         } else throw new Error(`Illegal state: cached verified data should be decrypted.`)
       } else {
         const created = await this.createNewExchangeData(delegateId, {
-          allowNoDelegateKeys: allowCreationWithoutDelegateKey,
+          allowNoDelegateKeys: options?.allowCreationWithoutDelegateKey ?? false,
+          allowNoDelegatorKeys: options?.allowCreationWithoutDelegatorKey ?? false,
         })
         const hashes = await this.accessControlSecret.allSecureDelegationKeysFor(created.accessControlSecret)
         const data = {
@@ -633,6 +772,7 @@ class LimitedLruCacheExchangeDataManager extends AbstractExchangeDataManager {
           decrypted: {
             accessControlSecret: created.accessControlSecret,
             exchangeKey: created.exchangeKey,
+            sharedSignatureKey: created.sharedSignatureKey,
             verified: true,
           },
           hashes,
@@ -640,8 +780,9 @@ class LimitedLruCacheExchangeDataManager extends AbstractExchangeDataManager {
         this.addToCache(data)
         return {
           exchangeData: data.exchangeData,
-          exchangeKey: data.decrypted!.exchangeKey,
-          accessControlSecret: data.decrypted!.accessControlSecret,
+          exchangeKey: data.decrypted.exchangeKey,
+          accessControlSecret: data.decrypted.accessControlSecret,
+          sharedSignatureKey: data.decrypted.sharedSignatureKey,
         }
       }
     } finally {
@@ -689,5 +830,30 @@ class LimitedLruCacheExchangeDataManager extends AbstractExchangeDataManager {
 
   getAllDelegationKeys(): Promise<string[] | undefined> {
     return Promise.resolve(undefined)
+  }
+
+  protected async cacheInjectedExchangeData(
+    exchangeDataDetails: {
+      exchangeData: ExchangeData
+      accessControlSecret: string
+      exchangeKey: CryptoKey
+      sharedSignatureKey: CryptoKey
+      verified: boolean
+    }[]
+  ): Promise<void> {
+    for (const details of exchangeDataDetails) {
+      const hashes = await this.accessControlSecret.allSecureDelegationKeysFor(details.accessControlSecret)
+      const data = {
+        exchangeData: details.exchangeData,
+        decrypted: {
+          accessControlSecret: details.accessControlSecret,
+          exchangeKey: details.exchangeKey,
+          sharedSignatureKey: details.sharedSignatureKey,
+          verified: details.verified,
+        },
+        hashes,
+      }
+      this.addToCache(data)
+    }
   }
 }

--- a/icc-x-api/crypto/ExtendedApisUtils.ts
+++ b/icc-x-api/crypto/ExtendedApisUtils.ts
@@ -113,6 +113,8 @@ export interface ExtendedApisUtils {
    * delegations for access control but don't actually have any encrypted content.
    * HealthcareElement).
    * @param autoDelegations automatically shares the metadata with the provided data owners, with the provided access level.
+   * @param alternateRootDelegation by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @throws if the entity already has non-empty values for encryption metadata.
    * @return an updated copy of the entity.
    */
@@ -122,7 +124,8 @@ export interface ExtendedApisUtils {
     owningEntity: string | undefined,
     owningEntitySecretIds: string[] | undefined,
     initialiseEncryptionKey: boolean,
-    autoDelegations: { [p: string]: SecureDelegation.AccessLevelEnum }
+    autoDelegations: { [p: string]: SecureDelegation.AccessLevelEnum },
+    alternateRootDelegation: string | undefined
   ): Promise<{ updatedEntity: T; rawEncryptionKey: string | undefined; secretId: string | undefined }>
 
   /**

--- a/icc-x-api/crypto/ExtendedApisUtilsImpl.ts
+++ b/icc-x-api/crypto/ExtendedApisUtilsImpl.ts
@@ -93,7 +93,8 @@ export class ExtendedApisUtilsImpl implements ExtendedApisUtils {
     owningEntity: string | undefined,
     owningEntitySecretIds: string[] | undefined,
     initialiseEncryptionKey: boolean,
-    autoDelegations: { [p: string]: SecureDelegation.AccessLevelEnum }
+    autoDelegations: { [p: string]: SecureDelegation.AccessLevelEnum },
+    alternateRootDelegation: string | undefined
   ): Promise<{ updatedEntity: T; rawEncryptionKey: string | undefined; secretId: string }> {
     this.throwDetailedExceptionForInvalidParameter('entity.id', entity.id, 'entityWithInitialisedEncryptedMetadata', arguments)
     this.checkEmptyEncryptionMetadata(entity)
@@ -109,7 +110,8 @@ export class ExtendedApisUtilsImpl implements ExtendedApisUtils {
         newSecretId ? [newSecretId] : [],
         !!owningEntity ? [owningEntity] : [],
         newRawKey ? [newRawKey] : [],
-        autoDelegations
+        autoDelegations,
+        alternateRootDelegation
       ),
       rawEncryptionKey: newRawKey,
       secretId: newSecretId,
@@ -783,7 +785,8 @@ export class ExtendedApisUtilsImpl implements ExtendedApisUtils {
       [],
       [],
       [await this.primitives.AES.generateCryptoKey(true)],
-      usersWithAccessToNewKey
+      usersWithAccessToNewKey,
+      undefined
     )
   }
 

--- a/icc-x-api/crypto/SecureDelegationsManager.ts
+++ b/icc-x-api/crypto/SecureDelegationsManager.ts
@@ -132,7 +132,7 @@ export class SecureDelegationsManager {
     shareOwningEntityIds: string[],
     newDelegationPermissions: EntityShareRequest.RequestedPermissionInternal
   ): Promise<EntityShareOrMetadataUpdateRequest | undefined> {
-    const exchangeDataInfo = await this.exchangeDataManager.getOrCreateEncryptionDataTo(delegateId, false)
+    const exchangeDataInfo = await this.exchangeDataManager.getOrCreateEncryptionDataTo(delegateId)
     const secureDelegationKey = await this.accessControlSecretUtils.secureDelegationKeyFor(exchangeDataInfo.accessControlSecret, entityWithType.type)
     const existingSecureDelegation = entityWithType.entity.securityMetadata?.secureDelegations?.[secureDelegationKey]
     if (existingSecureDelegation) {
@@ -228,7 +228,7 @@ export class SecureDelegationsManager {
     encryptedExchangeDataId: { [fp: string]: string } | undefined
   }> {
     // Be wary of explicit delegator and explicit delegate
-    const exchangeDataInfo = await this.exchangeDataManager.getOrCreateEncryptionDataTo(delegateId, false)
+    const exchangeDataInfo = await this.exchangeDataManager.getOrCreateEncryptionDataTo(delegateId)
     const accessControlHash = await this.accessControlSecretUtils.secureDelegationKeyFor(exchangeDataInfo.accessControlSecret, entity.type)
     const accessControlKey = ua2hex(await this.accessControlSecretUtils.accessControlKeyFor(exchangeDataInfo.accessControlSecret, entity.type))
     const encryptedDelegationInfo = await this.makeSecureDelegationEncryptedData(

--- a/icc-x-api/crypto/SecureDelegationsManager.ts
+++ b/icc-x-api/crypto/SecureDelegationsManager.ts
@@ -52,6 +52,8 @@ export class SecureDelegationsManager {
    * @param encryptionKeys the initial encryption keys to include and share with the auto-delegations
    * @param autoDelegations the data owners which will initially have access to the entity in addition to the current data owner and the access level
    * they will have on the entity.
+   * @param alternateRootDelegation by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return the entity with the security metadata initialised for the provided parameters.
    */
   async entityWithInitialisedEncryptedMetadata<T extends EncryptedEntity>(
@@ -60,19 +62,21 @@ export class SecureDelegationsManager {
     secretIds: string[],
     owningEntityIds: string[],
     encryptionKeys: string[],
-    autoDelegations: { [delegateId: string]: SecureDelegation.AccessLevelEnum }
+    autoDelegations: { [delegateId: string]: SecureDelegation.AccessLevelEnum },
+    alternateRootDelegation: string | undefined
   ): Promise<T> {
     const entityWithType: EncryptedEntityWithType = { entity, type: entityType }
+    const selfId = await this.dataOwnerApi.getCurrentDataOwnerId()
+    const rootDelegationDelegate = alternateRootDelegation ?? selfId
     const rootDelegationInfo = await this.makeSecureDelegationInfo(
       entityWithType,
-      await this.dataOwnerApi.getCurrentDataOwnerId(),
+      rootDelegationDelegate,
       secretIds,
       encryptionKeys,
       owningEntityIds,
       AccessLevelEnum.WRITE,
       undefined
     )
-    const selfId = await this.dataOwnerApi.getCurrentDataOwnerId()
     const otherDelegationsInfo: {
       delegationKey: string
       accessControlKeyHex: string
@@ -80,7 +84,7 @@ export class SecureDelegationsManager {
       encryptedExchangeDataId: { [fp: string]: string } | undefined
     }[] = []
     for (const [delegateId, permissions] of Object.entries(autoDelegations)) {
-      if (delegateId !== selfId) {
+      if (delegateId !== rootDelegationDelegate) {
         otherDelegationsInfo.push(
           await this.makeSecureDelegationInfo(
             entityWithType,

--- a/icc-x-api/crypto/SecureDelegationsManager.ts
+++ b/icc-x-api/crypto/SecureDelegationsManager.ts
@@ -101,8 +101,9 @@ export class SecureDelegationsManager {
     const secureDelegations = Object.fromEntries(
       [rootDelegationInfo, ...otherDelegationsInfo].map(({ delegationKey, delegation }) => [delegationKey, delegation])
     )
+    const delegationForExchangeDataMaps = selfId == rootDelegationDelegate ? otherDelegationsInfo : [rootDelegationInfo, ...otherDelegationsInfo]
     const newExchangeDataMaps = Object.fromEntries(
-      otherDelegationsInfo
+      delegationForExchangeDataMaps
         .filter(({ encryptedExchangeDataId }) => !!encryptedExchangeDataId)
         .map(({ accessControlKeyHex, encryptedExchangeDataId }) => [accessControlKeyHex, encryptedExchangeDataId!])
     )

--- a/icc-x-api/crypto/ShamirKeysManager.ts
+++ b/icc-x-api/crypto/ShamirKeysManager.ts
@@ -66,7 +66,7 @@ export class ShamirKeysManager {
     const delegatesKeys: { [delegateId: string]: CryptoKey } = {}
     let updatedSelf = self
     for (const delegateId of new Set(Object.values(keySplitsToUpdate).flatMap((x) => x.notariesIds))) {
-      const res = await this.exchangeDataManager.getOrCreateEncryptionDataTo(delegateId, false)
+      const res = await this.exchangeDataManager.getOrCreateEncryptionDataTo(delegateId)
       delegatesKeys[delegateId] = res.exchangeKey
     }
     for (const [key, params] of Object.entries(keySplitsToUpdate)) {

--- a/icc-x-api/crypto/UserEncryptionKeysManager.ts
+++ b/icc-x-api/crypto/UserEncryptionKeysManager.ts
@@ -307,7 +307,7 @@ export class UserEncryptionKeysManager {
       const whatToDo = await currentOwnerKeyGenerator(self)
       if (whatToDo === false) {
         throw new Error(`No verified key found for ${self.dataOwner.id} and settings do not allow creation of a new key.`)
-      } else if (whatToDo == 'keyless') {
+      } else if (typeof whatToDo == 'string' && whatToDo == 'keyless') {
         this.keysCache = keysCache
         return undefined
       } else {

--- a/icc-x-api/crypto/UserEncryptionKeysManager.ts
+++ b/icc-x-api/crypto/UserEncryptionKeysManager.ts
@@ -35,7 +35,7 @@ const nothingKeyRecovererAndVerifier: KeyRecovererAndVerifier = (x) =>
       }
     )
   )
-type CurrentOwnerKeyGenerator = (self: DataOwnerWithType) => Promise<KeyPair<CryptoKey> | boolean>
+type CurrentOwnerKeyGenerator = (self: DataOwnerWithType) => Promise<KeyPair<CryptoKey> | boolean | 'keyless'>
 
 /**
  * Allows to manage public and private keys for the current user and his parent hierarchy.
@@ -307,6 +307,9 @@ export class UserEncryptionKeysManager {
       const whatToDo = await currentOwnerKeyGenerator(self)
       if (whatToDo === false) {
         throw new Error(`No verified key found for ${self.dataOwner.id} and settings do not allow creation of a new key.`)
+      } else if (whatToDo == 'keyless') {
+        this.keysCache = keysCache
+        return undefined
       } else {
         const updateInfo = await this.createAndSaveNewKeyPair(whatToDo === true ? undefined : whatToDo, self)
         // self may be outdated now

--- a/icc-x-api/crypto/utils.ts
+++ b/icc-x-api/crypto/utils.ts
@@ -116,7 +116,8 @@ export async function ensureDelegationForSelf(
           undefined,
           undefined,
           true,
-          {}
+          {},
+          undefined
         )
         return { dataOwner: await patientApi.modifyPatient(updatedPatient.updatedEntity), type: DataOwnerTypeEnum.Patient }
       } else {

--- a/icc-x-api/icc-accesslog-x-api.ts
+++ b/icc-x-api/icc-accesslog-x-api.ts
@@ -57,6 +57,8 @@ export class IccAccesslogXApi extends IccAccesslogApi implements EncryptedEntity
    * auto-delegations, in such case the access level specified here will be used.
    * - preferredSfk: secret id of the patient to use as the secret foreign key to use for the access log. The default value will be a
    * secret id of patient known by the topmost parent in the current data owner hierarchy.
+   * - alternateRootDelegation: by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return a new instance of access log.
    */
   async newInstance(
@@ -66,6 +68,7 @@ export class IccAccesslogXApi extends IccAccesslogApi implements EncryptedEntity
     options: {
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
       sfkOption?: SecretIdUseOption
+      alternateRootDelegation?: string
     } = {}
   ) {
     const dataOwnerId = this.dataOwnerApi.getDataOwnerIdOf(user)
@@ -98,7 +101,15 @@ export class IccAccesslogXApi extends IccAccesslogApi implements EncryptedEntity
     }
     return new AccessLog(
       await this.crypto.xapi
-        .entityWithInitialisedEncryptedMetadata(accessLog, EntityWithDelegationTypeName.AccessLog, patient.id, sfk, true, extraDelegations)
+        .entityWithInitialisedEncryptedMetadata(
+          accessLog,
+          EntityWithDelegationTypeName.AccessLog,
+          patient.id,
+          sfk,
+          true,
+          extraDelegations,
+          options.alternateRootDelegation
+        )
         .then((x) => x.updatedEntity)
     )
   }
@@ -112,6 +123,8 @@ export class IccAccesslogXApi extends IccAccesslogApi implements EncryptedEntity
    * - additionalDelegates: delegates which will have access to the entity in addition to the current data owner and delegates from the
    * auto-delegations. Must be an object which associates each data owner id with the access level to give to that data owner. May overlap with
    * auto-delegations, in such case the access level specified here will be used.
+   * - alternateRootDelegation: by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return a new instance of access log.
    */
   async newInstanceNoPatient(
@@ -119,6 +132,7 @@ export class IccAccesslogXApi extends IccAccesslogApi implements EncryptedEntity
     h: any,
     options: {
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
+      alternateRootDelegation?: string
     } = {}
   ) {
     const dataOwnerId = this.dataOwnerApi.getDataOwnerIdOf(user)
@@ -147,7 +161,15 @@ export class IccAccesslogXApi extends IccAccesslogApi implements EncryptedEntity
     }
     return new AccessLog(
       await this.crypto.xapi
-        .entityWithInitialisedEncryptedMetadata(accessLog, EntityWithDelegationTypeName.AccessLog, undefined, undefined, true, extraDelegations)
+        .entityWithInitialisedEncryptedMetadata(
+          accessLog,
+          EntityWithDelegationTypeName.AccessLog,
+          undefined,
+          undefined,
+          true,
+          extraDelegations,
+          options.alternateRootDelegation
+        )
         .then((x) => x.updatedEntity)
     )
   }

--- a/icc-x-api/icc-calendar-item-x-api.ts
+++ b/icc-x-api/icc-calendar-item-x-api.ts
@@ -54,6 +54,7 @@ export class IccCalendarItemXApi extends IccCalendarItemApi implements Encrypted
     ci: any | CalendarItem,
     options: {
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
+      alternateRootDelegation?: string
     } = {}
   ) {
     return this.newInstancePatient(user, null, ci, options)
@@ -71,6 +72,8 @@ export class IccCalendarItemXApi extends IccCalendarItemApi implements Encrypted
    * auto-delegations, in such case the access level specified here will be used.
    * - preferredSfk: secret id of the patient to use as the secret foreign key to use for the classcalendar itemification. The default value will be a
    * secret id of patient known by the topmost parent in the current data owner hierarchy.
+   * - alternateRootDelegation: by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return a new instance of calendar item.
    */
   async newInstancePatient(
@@ -80,6 +83,7 @@ export class IccCalendarItemXApi extends IccCalendarItemApi implements Encrypted
     options: {
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
       sfkOption?: SecretIdUseOption
+      alternateRootDelegation?: string
     } = {}
   ): Promise<models.CalendarItem> {
     const calendarItem = {
@@ -111,7 +115,15 @@ export class IccCalendarItemXApi extends IccCalendarItemApi implements Encrypted
     }
     return new CalendarItem(
       await this.crypto.xapi
-        .entityWithInitialisedEncryptedMetadata(calendarItem, EntityWithDelegationTypeName.CalendarItem, patient?.id, sfk, true, extraDelegations)
+        .entityWithInitialisedEncryptedMetadata(
+          calendarItem,
+          EntityWithDelegationTypeName.CalendarItem,
+          patient?.id,
+          sfk,
+          true,
+          extraDelegations,
+          options.alternateRootDelegation
+        )
         .then((x) => x.updatedEntity)
     )
   }

--- a/icc-x-api/icc-classification-x-api.ts
+++ b/icc-x-api/icc-classification-x-api.ts
@@ -56,6 +56,8 @@ export class IccClassificationXApi extends IccClassificationApi implements Encry
    * auto-delegations, in such case the access level specified here will be used.
    * - preferredSfk: secret id of the patient to use as the secret foreign key to use for the classification. The default value will be a
    * secret id of patient known by the topmost parent in the current data owner hierarchy.
+   * - alternateRootDelegation: by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return a new instance of classification.
    */
   async newInstance(
@@ -65,6 +67,7 @@ export class IccClassificationXApi extends IccClassificationApi implements Encry
     options: {
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
       sfkOption?: SecretIdUseOption
+      alternateRootDelegation?: string
     } = {}
   ): Promise<models.Classification> {
     const classification = {
@@ -95,7 +98,15 @@ export class IccClassificationXApi extends IccClassificationApi implements Encry
     }
     return new models.Classification(
       await this.crypto.xapi
-        .entityWithInitialisedEncryptedMetadata(classification, EntityWithDelegationTypeName.Classification, patient?.id, sfk, true, extraDelegations)
+        .entityWithInitialisedEncryptedMetadata(
+          classification,
+          EntityWithDelegationTypeName.Classification,
+          patient?.id,
+          sfk,
+          true,
+          extraDelegations,
+          options.alternateRootDelegation
+        )
         .then((x) => x.updatedEntity)
     )
   }

--- a/icc-x-api/icc-contact-x-api.ts
+++ b/icc-x-api/icc-contact-x-api.ts
@@ -99,6 +99,8 @@ export class IccContactXApi extends IccContactApi implements EncryptedEntityXApi
    * the data owner did not share with any of his parents.
    * - confidential: if true, the entity will be created as confidential. Confidential entities are not shared with auto-delegations, and the default
    * foreign key used is any key that is not shared with any of the data owner parents. By default entities are created as non-confidential.
+   * - alternateRootDelegation: by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return a new instance of contact.
    */
   async newInstance(
@@ -109,6 +111,7 @@ export class IccContactXApi extends IccContactApi implements EncryptedEntityXApi
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
       sfkOption?: SecretIdUseOption
       ignoreAutoDelegations?: boolean // default is considered false
+      alternateRootDelegation?: string
     } = {}
   ): Promise<models.Contact> {
     const contact = new models.Contact({
@@ -147,7 +150,8 @@ export class IccContactXApi extends IccContactApi implements EncryptedEntityXApi
       patient.id,
       sfk,
       true,
-      extraDelegations
+      extraDelegations,
+      options.alternateRootDelegation
     )
     return new models.Contact(initialisationInfo.updatedEntity)
   }

--- a/icc-x-api/icc-crypto-x-api.ts
+++ b/icc-x-api/icc-crypto-x-api.ts
@@ -162,4 +162,50 @@ export class IccCryptoXApi {
   async getCurrentUserAvailablePublicKeysHex(verifiedOnly: boolean): Promise<string[]> {
     return this._keyManager.getCurrentUserAvailablePublicKeysHex(verifiedOnly)
   }
+
+  /**
+   * The only way of creating exchange data to a delegate when the SDK runs in keyless mode.
+   * @param delegate a delegate, can't be the current data owner
+   * @return the created exchange data details. They can be used to inject the data in a separate instance of the SDK,
+   * allowing the data created by this instance to be retrieved.
+   */
+  async keylessCreateExchangeDataTo(delegate: string): Promise<{
+    exchangeDataId: string
+    accessControlSecret: ArrayBuffer
+    exchangeKey: ArrayBuffer
+    sharedSignatureKey: ArrayBuffer
+  }> {
+    if (delegate == (await this._dataOwnerApi.getCurrentDataOwnerId())) throw new Error("Can't create exchange data to yourself in keyless mode.")
+    if (this.userKeysManager.getSelfVerifiedKeys().length > 0) throw new Error('This method can only be used in keyless mode.')
+    const created = await this.exchangeData.getOrCreateEncryptionDataTo(delegate, { allowCreationWithoutDelegatorKey: true })
+    return {
+      exchangeDataId: created.exchangeData.id!,
+      accessControlSecret: await this.exchangeData.base.exportAccessControlSecret(created.accessControlSecret),
+      exchangeKey: await this.exchangeData.base.exportExchangeKey(created.exchangeKey),
+      sharedSignatureKey: await this.exchangeData.base.exportSharedSignatureKey(created.sharedSignatureKey),
+    }
+  }
+
+  /**
+   * Allows injecting exchange data that would not be readable or decryptable by the SDK otherwise.
+   * IMPORTANT: the SDK will not check that the provided exchange data details are valid for the provided exchange data
+   * id. Providing invalid details could cause permanent corruption of data.
+   * @param details the details of the exchange data to inject. Set verified to true to allow this data to be used for
+   * encryption of new entity.
+   * @param reEncryptWithOwnKeys can only be true if the api wasn't initialized in keyless mode. If true the injected
+   * data will be re-encrypted with also the current data owner key, allowing to access it in future instances without
+   * having to re-inject it (as long as the instance has access to the current private key).
+   */
+  async injectExchangeData(
+    details: {
+      exchangeDataId: string
+      accessControlSecret: ArrayBuffer
+      exchangeKey: ArrayBuffer
+      sharedSignatureKey: ArrayBuffer
+      verified: boolean
+    }[],
+    reEncryptWithOwnKeys: boolean
+  ) {
+    await this.exchangeData.injectDecryptedExchangeData(details, reEncryptWithOwnKeys)
+  }
 }

--- a/icc-x-api/icc-document-x-api.ts
+++ b/icc-x-api/icc-document-x-api.ts
@@ -590,6 +590,8 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
    * auto-delegations, in such case the access level specified here will be used.
    * - preferredSfk: secret id of the message to use as the secret foreign key to use for the document. The default value will be a
    * secret id of the message known by the topmost parent in the current data owner hierarchy.
+   * - alternateRootDelegation: by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return a new instance of document.
    */
   async newInstance(
@@ -599,6 +601,7 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
     options: {
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
       sfkOption?: SecretIdUseOption
+      alternateRootDelegation?: string
     } = {}
   ) {
     const document = {
@@ -629,7 +632,15 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
     }
     return new models.Document(
       await this.crypto.xapi
-        .entityWithInitialisedEncryptedMetadata(document, EntityWithDelegationTypeName.Document, message?.id, sfk, true, extraDelegations)
+        .entityWithInitialisedEncryptedMetadata(
+          document,
+          EntityWithDelegationTypeName.Document,
+          message?.id,
+          sfk,
+          true,
+          extraDelegations,
+          options.alternateRootDelegation
+        )
         .then((x) => x.updatedEntity)
     )
   }

--- a/icc-x-api/icc-form-x-api.ts
+++ b/icc-x-api/icc-form-x-api.ts
@@ -56,6 +56,8 @@ export class IccFormXApi extends IccFormApi implements EncryptedEntityXApi<model
    * auto-delegations, in such case the access level specified here will be used.
    * - preferredSfk: secret id of the patient to use as the secret foreign key to use for the form. The default value will be a
    * secret id of patient known by the topmost parent in the current data owner hierarchy.
+   * - alternateRootDelegation: by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return a new instance of form.
    */
   async newInstance(
@@ -65,6 +67,7 @@ export class IccFormXApi extends IccFormApi implements EncryptedEntityXApi<model
     options: {
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
       sfkOption?: SecretIdUseOption
+      alternateRootDelegation?: string
     } = {}
   ) {
     const form = {
@@ -93,7 +96,15 @@ export class IccFormXApi extends IccFormApi implements EncryptedEntityXApi<model
     }
     return new models.Form(
       await this.crypto.xapi
-        .entityWithInitialisedEncryptedMetadata(form, EntityWithDelegationTypeName.Form, patient.id, sfk, true, extraDelegations)
+        .entityWithInitialisedEncryptedMetadata(
+          form,
+          EntityWithDelegationTypeName.Form,
+          patient.id,
+          sfk,
+          true,
+          extraDelegations,
+          options.alternateRootDelegation
+        )
         .then((x) => x.updatedEntity)
     )
   }

--- a/icc-x-api/icc-helement-x-api.ts
+++ b/icc-x-api/icc-helement-x-api.ts
@@ -64,6 +64,8 @@ export class IccHelementXApi extends IccHelementApi implements EncryptedEntityXA
    * the data owner did not share with any of his parents.
    * - confidential: if true, the entity will be created as confidential. Confidential entities are not shared with auto-delegations, and the default
    * foreign key used is any key that is not shared with any of the data owner parents. By default entities are created as non-confidential.
+   * - alternateRootDelegation: by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return a new instance of health element.
    */
   async newInstance(
@@ -74,6 +76,7 @@ export class IccHelementXApi extends IccHelementApi implements EncryptedEntityXA
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
       sfkOption?: SecretIdUseOption
       ignoreAutoDelegations?: boolean
+      alternateRootDelegation?: string
     } = {}
   ) {
     const dataOwnerId = this.dataOwnerApi.getDataOwnerIdOf(user)
@@ -111,7 +114,8 @@ export class IccHelementXApi extends IccHelementApi implements EncryptedEntityXA
       patient.id,
       sfk,
       true,
-      extraDelegations
+      extraDelegations,
+      options.alternateRootDelegation
     )
     return new models.HealthElement(initialisationInfo.updatedEntity)
   }

--- a/icc-x-api/icc-invoice-x-api.ts
+++ b/icc-x-api/icc-invoice-x-api.ts
@@ -51,6 +51,8 @@ export class IccInvoiceXApi extends IccInvoiceApi implements EncryptedEntityXApi
    * auto-delegations, in such case the access level specified here will be used.
    * - preferredSfk: secret id of the patient to use as the secret foreign key to use for the invoice. The default value will be a
    * secret id of patient known by the topmost parent in the current data owner hierarchy.
+   * - alternateRootDelegation: by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return a new instance of invoice.
    */
   async newInstance(
@@ -60,6 +62,7 @@ export class IccInvoiceXApi extends IccInvoiceApi implements EncryptedEntityXApi
     options: {
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
       sfkOption?: SecretIdUseOption
+      alternateRootDelegation?: string
     } = {}
   ): Promise<models.Invoice> {
     const invoice = new models.Invoice({
@@ -90,7 +93,15 @@ export class IccInvoiceXApi extends IccInvoiceApi implements EncryptedEntityXApi
     }
     return new models.Invoice(
       await this.crypto.xapi
-        .entityWithInitialisedEncryptedMetadata(invoice, EntityWithDelegationTypeName.Invoice, patient.id, sfk, true, extraDelegations)
+        .entityWithInitialisedEncryptedMetadata(
+          invoice,
+          EntityWithDelegationTypeName.Invoice,
+          patient.id,
+          sfk,
+          true,
+          extraDelegations,
+          options.alternateRootDelegation
+        )
         .then((x) => x.updatedEntity)
     )
   }

--- a/icc-x-api/icc-maintenance-task-x-api.ts
+++ b/icc-x-api/icc-maintenance-task-x-api.ts
@@ -59,6 +59,8 @@ export class IccMaintenanceTaskXApi extends IccMaintenanceTaskApi implements Enc
    * - additionalDelegates: delegates which will have access to the entity in addition to the current data owner and delegates from the
    * auto-delegations. Must be an object which associates each data owner id with the access level to give to that data owner. May overlap with
    * auto-delegations, in such case the access level specified here will be used.
+   * - alternateRootDelegation: by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return a new instance of maintenance task.
    */
   async newInstance(
@@ -66,6 +68,7 @@ export class IccMaintenanceTaskXApi extends IccMaintenanceTaskApi implements Enc
     m: any,
     options: {
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
+      alternateRootDelegation?: string
     } = {}
   ) {
     const dataOwnerId = this.dataOwnerApi.getDataOwnerIdOf(user)
@@ -91,7 +94,8 @@ export class IccMaintenanceTaskXApi extends IccMaintenanceTaskApi implements Enc
           undefined,
           undefined,
           true,
-          extraDelegations
+          extraDelegations,
+          options.alternateRootDelegation
         )
         .then((x) => x.updatedEntity)
     )

--- a/icc-x-api/icc-message-x-api.ts
+++ b/icc-x-api/icc-message-x-api.ts
@@ -62,6 +62,8 @@ export class IccMessageXApi extends IccMessageApi implements EncryptedEntityXApi
    * auto-delegations, in such case the access level specified here will be used.
    * - preferredSfk: secret id of the patient to use as the secret foreign key to use for the message. The default value will be a
    * secret id of patient known by the topmost parent in the current data owner hierarchy.
+   * - alternateRootDelegation: by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return a new instance of message.
    */
   async newInstanceWithPatient(
@@ -71,6 +73,7 @@ export class IccMessageXApi extends IccMessageApi implements EncryptedEntityXApi
     options: {
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
       sfkOption?: SecretIdUseOption
+      alternateRootDelegation?: string
     } = {}
   ) {
     const message = {
@@ -102,7 +105,15 @@ export class IccMessageXApi extends IccMessageApi implements EncryptedEntityXApi
     }
     return new models.Message(
       await this.crypto.xapi
-        .entityWithInitialisedEncryptedMetadata(message, EntityWithDelegationTypeName.Message, patient?.id, sfk, true, extraDelegations)
+        .entityWithInitialisedEncryptedMetadata(
+          message,
+          EntityWithDelegationTypeName.Message,
+          patient?.id,
+          sfk,
+          true,
+          extraDelegations,
+          options.alternateRootDelegation
+        )
         .then((x) => x.updatedEntity)
     )
   }

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -78,6 +78,8 @@ export class IccPatientXApi extends IccPatientApi implements EncryptedEntityXApi
    * - additionalDelegates: delegates which will have access to the entity in addition to the current data owner and delegates from the
    * auto-delegations. Must be an object which associates each data owner id with the access level to give to that data owner. May overlap with
    * auto-delegations, in such case the access level specified here will be used.
+   * - alternateRootDelegation: by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return a new instance of patient.
    */
   async newInstance(
@@ -85,6 +87,7 @@ export class IccPatientXApi extends IccPatientApi implements EncryptedEntityXApi
     p: any = {},
     options: {
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
+      alternateRootDelegation?: string
     } = {}
   ) {
     const patient = {
@@ -113,7 +116,8 @@ export class IccPatientXApi extends IccPatientApi implements EncryptedEntityXApi
       undefined,
       undefined,
       true,
-      extraDelegations
+      extraDelegations,
+      options.alternateRootDelegation
     )
     return new models.Patient(initialisationInfo.updatedEntity)
   }

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -1304,7 +1304,9 @@ export class IccPatientXApi extends IccPatientApi implements EncryptedEntityXApi
   async forceInitialiseExchangeDataToNewlyInvitedPatient(patientId: string): Promise<boolean> {
     const patient = await super.getPatient(patientId)
     if (this.dataOwnerApi.getHexPublicKeysOf(patient).size) return false
-    await this.crypto.exchangeData.getOrCreateEncryptionDataTo(patientId, true)
+    await this.crypto.exchangeData.getOrCreateEncryptionDataTo(patientId, {
+      allowCreationWithoutDelegateKey: true,
+    })
     return true
   }
 }

--- a/icc-x-api/icc-receipt-x-api.ts
+++ b/icc-x-api/icc-receipt-x-api.ts
@@ -46,6 +46,8 @@ export class IccReceiptXApi extends IccReceiptApi implements EncryptedEntityXApi
    * - additionalDelegates: delegates which will have access to the entity in addition to the current data owner and delegates from the
    * auto-delegations. Must be an object which associates each data owner id with the access level to give to that data owner. May overlap with
    * auto-delegations, in such case the access level specified here will be used.
+   * - alternateRootDelegation: by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return a new instance of receipt.
    */
   async newInstance(
@@ -53,6 +55,7 @@ export class IccReceiptXApi extends IccReceiptApi implements EncryptedEntityXApi
     r: any,
     options: {
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
+      alternateRootDelegation?: string
     } = {}
   ): Promise<models.Receipt> {
     const receipt = new models.Receipt({
@@ -75,7 +78,15 @@ export class IccReceiptXApi extends IccReceiptApi implements EncryptedEntityXApi
     }
     return new models.Receipt(
       await this.crypto.xapi
-        .entityWithInitialisedEncryptedMetadata(receipt, EntityWithDelegationTypeName.Receipt, undefined, undefined, true, extraDelegations)
+        .entityWithInitialisedEncryptedMetadata(
+          receipt,
+          EntityWithDelegationTypeName.Receipt,
+          undefined,
+          undefined,
+          true,
+          extraDelegations,
+          options.alternateRootDelegation
+        )
         .then((x) => x.updatedEntity)
     )
   }

--- a/icc-x-api/icc-recovery-x-api.ts
+++ b/icc-x-api/icc-recovery-x-api.ts
@@ -158,13 +158,14 @@ export class IccRecoveryXApi {
       if (!retrievedData) {
         console.warn(`Could not recover exchange data with id ${exchangeDataInfo.exchangeDataId} as it was not found. Ignoring`)
       } else {
-        await this.exchangeData.base.updateExchangeDataWithRawDecryptedContent(
-          retrievedData,
-          selfEncryptionKeys,
-          exchangeDataInfo.rawExchangeKey,
-          exchangeDataInfo.rawAccessControlSecret,
-          exchangeDataInfo.rawSharedSignatureKey
-        )
+        await this.exchangeData.base.updateExchangeDataWithRawDecryptedContent({
+          exchangeData: retrievedData,
+          newEncryptionKeys: selfEncryptionKeys,
+          rawExchangeKey: exchangeDataInfo.rawExchangeKey,
+          rawAccessControlSecret: exchangeDataInfo.rawAccessControlSecret,
+          rawSharedSignatureKey: exchangeDataInfo.rawSharedSignatureKey,
+          newDelegatorSignatureKeys: {},
+        })
       }
     }
     await this.baseRecoveryApi.deleteRecoveryData(await this.recoveryDataEncryption.recoveryKeyToId(recoveryKey)).catch((e) => {

--- a/icc-x-api/icc-time-table-x-api.ts
+++ b/icc-x-api/icc-time-table-x-api.ts
@@ -53,6 +53,8 @@ export class IccTimeTableXApi extends IccTimeTableApi implements EncryptedEntity
    * - additionalDelegates: delegates which will have access to the entity in addition to the current data owner and delegates from the
    * auto-delegations. Must be an object which associates each data owner id with the access level to give to that data owner. May overlap with
    * auto-delegations, in such case the access level specified here will be used.
+   * - alternateRootDelegation: by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return a new instance of timetable.
    */
   async newInstance(
@@ -61,6 +63,7 @@ export class IccTimeTableXApi extends IccTimeTableApi implements EncryptedEntity
     options: {
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
       preferredSfk?: string
+      alternateRootDelegation?: string
     } = {}
   ) {
     const timeTable: TimeTable = {
@@ -83,7 +86,15 @@ export class IccTimeTableXApi extends IccTimeTableApi implements EncryptedEntity
 
     return new models.TimeTable(
       await this.crypto.xapi
-        .entityWithInitialisedEncryptedMetadata(timeTable, EntityWithDelegationTypeName.TimeTable, undefined, undefined, true, extraDelegations)
+        .entityWithInitialisedEncryptedMetadata(
+          timeTable,
+          EntityWithDelegationTypeName.TimeTable,
+          undefined,
+          undefined,
+          true,
+          extraDelegations,
+          options.alternateRootDelegation
+        )
         .then((x) => x.updatedEntity)
     )
   }

--- a/icc-x-api/icc-topic-x-api.ts
+++ b/icc-x-api/icc-topic-x-api.ts
@@ -61,6 +61,8 @@ export class IccTopicXApi extends IccTopicApi implements EncryptedEntityXApi<mod
    * auto-delegations, in such case the access level specified here will be used.
    * - preferredSfk: secret id of the patient to use as the secret foreign key to use for the topic. The default value will be a
    * secret id of patient known by the topmost parent in the current data owner hierarchy.
+   * - alternateRootDelegation: by default a new entity is created with a root delegation from self to self. In keyless mode this is not possible,
+   * and instead the root delegation will be from self to another. You have to specify which delegate will be part of the root delegation.
    * @return a new instance of topic.
    */
   async newInstance(
@@ -70,6 +72,7 @@ export class IccTopicXApi extends IccTopicApi implements EncryptedEntityXApi<mod
     options: {
       additionalDelegates?: { [dataOwnerId: string]: AccessLevelEnum }
       sfkOption?: SecretIdUseOption
+      alternateRootDelegation?: string
     } = {}
   ) {
     if (!patient && options.sfkOption) throw new Error('preferredSfk can only be specified if patient is specified.')
@@ -104,7 +107,15 @@ export class IccTopicXApi extends IccTopicApi implements EncryptedEntityXApi<mod
 
     return new models.Topic(
       await this.crypto.xapi
-        .entityWithInitialisedEncryptedMetadata(topic, EntityWithDelegationTypeName.Topic, patient?.id, sfk, true, extraDelegations)
+        .entityWithInitialisedEncryptedMetadata(
+          topic,
+          EntityWithDelegationTypeName.Topic,
+          patient?.id,
+          sfk,
+          true,
+          extraDelegations,
+          options.alternateRootDelegation
+        )
         .then((x) => x.updatedEntity)
     )
   }

--- a/icc-x-api/index.ts
+++ b/icc-x-api/index.ts
@@ -256,6 +256,22 @@ export interface IcureApiOptions {
    * Set it to true only for connecting to kraken-lite versions < 0.1.187
    */
   readonly useLiteCompatibilityMode?: boolean
+  /**
+   * Allows injecting exchange data similarly to {@link IccCryptoXApi.injectExchangeData} but directly on
+   * initialization.
+   * When possible, this solution should be preferred as it allows minimizing proliferation of exchange data under
+   * certain circumstances.
+   */
+  readonly injectExchangeData?: {
+    details: {
+      exchangeDataId: string
+      accessControlSecret: ArrayBuffer
+      exchangeKey: ArrayBuffer
+      sharedSignatureKey: ArrayBuffer
+      verified: boolean
+    }[]
+    reEncryptWithOwnKeys: boolean
+  }
 }
 
 namespace IcureApiOptions {
@@ -274,6 +290,7 @@ namespace IcureApiOptions {
     readonly encryptedFieldsConfig: EncryptedFieldsConfig
     readonly groupSelector: (availableGroupsInfo: UserGroup[]) => Promise<string>
     readonly disableParentKeysInitialisation: boolean
+    readonly injectExchangeData: IcureApiOptions['injectExchangeData'] | undefined
 
     constructor(custom: IcureApiOptions) {
       this.entryKeysFactory = custom.entryKeysFactory ?? Defaults.entryKeysFactory
@@ -284,6 +301,7 @@ namespace IcureApiOptions {
       this.encryptedFieldsConfig = custom.encryptedFieldsConfig ?? {}
       this.groupSelector = custom.groupSelector ?? ((groups) => Promise.resolve(groups[0].groupId!))
       this.disableParentKeysInitialisation = custom.disableParentKeysInitialisation ?? false
+      this.injectExchangeData = custom.injectExchangeData
     }
   }
 }
@@ -778,6 +796,9 @@ async function initialiseCryptoWithProvider(
     cryptoPrimitives,
     !params.disableParentKeysInitialisation
   )
+  if (params.injectExchangeData != null && params.injectExchangeData.details.length > 0) {
+    await exchangeDataManager.injectDecryptedExchangeData(params.injectExchangeData.details, params.injectExchangeData.reEncryptWithOwnKeys)
+  }
   const exchangeDataMapManager = new ExchangeDataMapManager(
     new IccExchangeDataMapApi(host, updatedHeaders, groupSpecificAuthenticationProvider, fetchImpl)
   )

--- a/icc-x-api/index.ts
+++ b/icc-x-api/index.ts
@@ -809,7 +809,9 @@ async function initialiseCryptoWithProvider(
     !params.disableParentKeysInitialisation
   )
   const shamirManager = new ShamirKeysManager(cryptoPrimitives, dataOwnerApi, userEncryptionKeysManager, exchangeDataManager)
-  await ensureDelegationForSelf(dataOwnerApi, xApiUtils, basePatientApi, cryptoPrimitives)
+  if (userEncryptionKeysManager.getSelfVerifiedKeys().length > 0) {
+    await ensureDelegationForSelf(dataOwnerApi, xApiUtils, basePatientApi, cryptoPrimitives)
+  }
   const accessControlKeysHeadersProvider = new AccessControlKeysHeadersProvider(exchangeDataManager)
   const delegationsDeAnonymisation = new DelegationsDeAnonymization(
     dataOwnerApi,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icure/api",
-  "version": "8.1.6",
+  "version": "8.2.0",
   "description": "Typescript version of iCure standalone API client",
   "types": "dist/index.d.ts",
   "dependencies": {

--- a/test/icc-x-api/autofix-anonymity-test.ts
+++ b/test/icc-x-api/autofix-anonymity-test.ts
@@ -84,10 +84,23 @@ describe('Autofix anonymity tests', () => {
     )
     const createdByBackend = await api.agendaApi.createAgenda({ id: api.cryptoApi.primitives.randomUuid(), name: 'whatever' })
     if (isAnonymous) {
-      expect(createdWithNewInstance.author).to.eq('*')
-      expect(createdWithNewInstance.responsible).to.eq('*')
-      expect(createdByBackend.author).to.eq('*')
-      expect(createdByBackend.responsible).to.eq('*')
+      expect(createdWithNewInstance.author).to.eq(undefined)
+      expect(createdWithNewInstance.responsible).to.eq(undefined)
+      expect(createdByBackend.author).to.eq(undefined)
+      expect(createdByBackend.responsible).to.eq(undefined)
+    } else {
+      const doId = api.dataOwnerApi.getDataOwnerIdOf(user)
+      expect(createdWithNewInstance.author).to.eq(user.id)
+      expect(createdWithNewInstance.responsible).to.eq(doId)
+      expect(createdByBackend.author).to.eq(user.id)
+      expect(createdByBackend.responsible).to.eq(doId)
+    }
+    const modified = await api.agendaApi.modifyAgenda({ ...createdByBackend, name: 'whatever 2' })
+    if (isAnonymous) {
+      expect(createdWithNewInstance.author).to.eq(undefined)
+      expect(createdWithNewInstance.responsible).to.eq(undefined)
+      expect(createdByBackend.author).to.eq(undefined)
+      expect(createdByBackend.responsible).to.eq(undefined)
     } else {
       const doId = api.dataOwnerApi.getDataOwnerIdOf(user)
       expect(createdWithNewInstance.author).to.eq(user.id)

--- a/test/icc-x-api/crypto/exchange-data-manager-test.ts
+++ b/test/icc-x-api/crypto/exchange-data-manager-test.ts
@@ -204,8 +204,8 @@ describe('Exchange data manager - unit', async function () {
       await initialiseComponents(allowFullExchangeDataLoad)
       const sfk = primitives.randomUuid()
       const initialisedCount = exchangeDataApi.callCount
-      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
-      const retrievedCachedData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
+      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
+      const retrievedCachedData = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
       exchangeDataApi.compareCallCountFromBaseline(initialisedCount, {
         createExchangeData: 1,
         // If we could fully preload we already know whether the exchange key already exists or not, otherwise we have to request from the api
@@ -223,7 +223,7 @@ describe('Exchange data manager - unit', async function () {
       expect(decryptedAccessControlSecretByDelegate.successfulDecryptions[0]).to.equal(createdData.accessControlSecret)
       expect(retrievedCachedData.exchangeData.delegator).to.equal(selfId)
       expect(retrievedCachedData.exchangeData.delegate).to.equal(delegateId)
-      expect(Object.keys(retrievedCachedData.exchangeData.delegatorSignature)).to.have.length(1)
+      expect(Object.keys(retrievedCachedData.exchangeData.delegatorSignature ?? {})).to.have.length(1)
       expect(Object.keys(retrievedCachedData.exchangeData.exchangeKey)).to.have.length(2)
       expect(Object.keys(retrievedCachedData.exchangeData.accessControlSecret)).to.have.length(2)
       expect(Object.keys(retrievedCachedData.exchangeData.sharedSignatureKey)).to.have.length(2)
@@ -235,10 +235,10 @@ describe('Exchange data manager - unit', async function () {
   it('should create encryption keys to self when none is available', async function () {
     async function doTest(allowFullExchangeDataLoad: boolean) {
       await initialiseComponents(allowFullExchangeDataLoad)
-      const createdData = await exchangeData.getOrCreateEncryptionDataTo(selfId, false)
+      const createdData = await exchangeData.getOrCreateEncryptionDataTo(selfId)
       expect(createdData.exchangeData.delegator).to.equal(selfId)
       expect(createdData.exchangeData.delegate).to.equal(selfId)
-      expect(Object.keys(createdData.exchangeData.delegatorSignature)).to.have.length(1)
+      expect(Object.keys(createdData.exchangeData.delegatorSignature ?? {})).to.have.length(1)
       expect(Object.keys(createdData.exchangeData.sharedSignatureKey)).to.have.length(1)
       expect(Object.keys(createdData.exchangeData.exchangeKey)).to.have.length(1)
       expect(Object.keys(createdData.exchangeData.accessControlSecret)).to.have.length(1)
@@ -265,7 +265,7 @@ describe('Exchange data manager - unit', async function () {
         await dataOwnerApi.addPublicKeyForOwner(selfId, keyData.pair)
         await encryptionKeysManager.addOrUpdateKey(primitives, keyData.pair, false)
       }
-      const created = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
+      const created = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
       expect(
         setEquals(new Set(Object.keys(created.exchangeData.exchangeKey)), new Set(Object.keys(created.exchangeData.accessControlSecret))),
         'Keys used for encryption of exchange key and access control secret must be the same.'
@@ -297,10 +297,10 @@ describe('Exchange data manager - unit', async function () {
   it('should reuse existing exchange data for encryption when it can be verified', async function () {
     async function doTest(allowFullExchangeDataLoad: boolean) {
       await initialiseComponents(allowFullExchangeDataLoad)
-      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
+      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
       await exchangeData.clearOrRepopulateCache()
       const countAfterCacheClear = exchangeDataApi.callCount
-      const reloadedData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
+      const reloadedData = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
       exchangeDataApi.compareCallCountFromBaseline(countAfterCacheClear, {
         createExchangeData: 0,
         getExchangeDataByDelegatorDelegate: allowFullExchangeDataLoad ? 0 : 1,
@@ -317,11 +317,11 @@ describe('Exchange data manager - unit', async function () {
   it('should create new exchange data for encryption when the existing data can not be verified due to unavailable verification key', async function () {
     async function doTest(allowFullExchangeDataLoad: boolean) {
       await initialiseComponents(allowFullExchangeDataLoad)
-      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
+      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
       await encryptionKeysManager.unverifyExistingKeysAndCreateNewVerified(primitives)
       await exchangeData.clearOrRepopulateCache()
       const countAfterCacheClear = exchangeDataApi.callCount
-      const newData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
+      const newData = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
       exchangeDataApi.compareCallCountFromBaseline(countAfterCacheClear, {
         createExchangeData: 1,
         getExchangeDataByDelegatorDelegate: allowFullExchangeDataLoad ? 0 : 1,
@@ -349,12 +349,12 @@ describe('Exchange data manager - unit', async function () {
     ) {
       await initialiseComponents(allowFullExchangeDataLoad)
       const sfk = primitives.randomUuid()
-      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
+      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
       // Tamper with exchange data
       await exchangeDataApi.modifyExchangeData(await tamper(createdData.exchangeData, selfKeypair, selfKeyFpV2))
       await exchangeData.clearOrRepopulateCache()
       const countAfterCacheClear = exchangeDataApi.callCount
-      const newData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
+      const newData = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
       exchangeDataApi.compareCallCountFromBaseline(countAfterCacheClear, {
         createExchangeData: 1,
         getExchangeDataByDelegatorDelegate: allowFullExchangeDataLoad ? 0 : 1,
@@ -417,7 +417,7 @@ describe('Exchange data manager - unit', async function () {
   it('should create new exchange data for encryption when the existing data can not be verified due to tampering of the delegate id', async function () {
     async function doTest(allowFullExchangeDataLoad: boolean) {
       await initialiseComponents(allowFullExchangeDataLoad)
-      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
+      const createdData = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
       // Tamper with exchange data
       await exchangeDataApi.modifyExchangeData({
         ...createdData.exchangeData,
@@ -425,8 +425,8 @@ describe('Exchange data manager - unit', async function () {
       })
       await exchangeData.clearOrRepopulateCache()
       const countAfterCacheClear = exchangeDataApi.callCount
-      const newDataToDelegate = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
-      const newDataToDelegate2 = await exchangeData.getOrCreateEncryptionDataTo(delegate2Id, false)
+      const newDataToDelegate = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
+      const newDataToDelegate2 = await exchangeData.getOrCreateEncryptionDataTo(delegate2Id)
       exchangeDataApi.compareCallCountFromBaseline(countAfterCacheClear, {
         createExchangeData: 2,
         getExchangeDataByDelegatorDelegate: allowFullExchangeDataLoad ? 0 : 2,
@@ -466,7 +466,7 @@ describe('Exchange data manager - unit', async function () {
   it('should return existing exchange data keys for decryption even if the data authenticity could not be verified', async function () {
     async function doTest(allowFullExchangeDataLoad: boolean) {
       await initialiseComponents(allowFullExchangeDataLoad)
-      const createdData1 = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
+      const createdData1 = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
       const createdData2 = await createDataFromRandomToSelf()
       await encryptionKeysManager.unverifyExistingKeysAndCreateNewVerified(primitives)
       await exchangeData.clearOrRepopulateCache()
@@ -490,7 +490,7 @@ describe('Exchange data manager - unit', async function () {
   it('newly created data or data retrieved by id should be cached and retrievable by hash', async function () {
     async function doTest(allowFullExchangeDataLoad: boolean) {
       await initialiseComponents(allowFullExchangeDataLoad)
-      const createdData1 = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
+      const createdData1 = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
       const hashes1 = await accessControlSecretUtils.allSecureDelegationKeysFor(createdData1.accessControlSecret)
       const retrievedKeys1 = await exchangeData.getCachedDecryptionDataKeyByAccessControlHash(hashes1)
       for (const hash of hashes1) {
@@ -518,7 +518,7 @@ describe('Exchange data manager - unit', async function () {
   it('if data can not be decrypted the retrieval method should return undefined', async function () {
     async function doTest(allowFullExchangeDataLoad: boolean) {
       await initialiseComponents(allowFullExchangeDataLoad)
-      const createdBySelf = await exchangeData.getOrCreateEncryptionDataTo(selfId, false)
+      const createdBySelf = await exchangeData.getOrCreateEncryptionDataTo(selfId)
       const createdByOther = await createDataFromRandomToSelf()
       const newKey = await primitives.RSA.generateKeyPair(ShaVersion.Sha256)
       await dataOwnerApi.addPublicKeyForOwner(selfId, newKey)
@@ -542,7 +542,7 @@ describe('Exchange data manager - unit', async function () {
   it('unverified keys should still be usable for decryption of data', async function () {
     async function doTest(allowFullExchangeDataLoad: boolean) {
       await initialiseComponents(allowFullExchangeDataLoad)
-      const createdBySelf = await exchangeData.getOrCreateEncryptionDataTo(selfId, false)
+      const createdBySelf = await exchangeData.getOrCreateEncryptionDataTo(selfId)
       const createdByOther = await createDataFromRandomToSelf()
       await encryptionKeysManager.addOrUpdateKey(primitives, selfKeypair, false)
       await exchangeData.clearOrRepopulateCache()
@@ -575,7 +575,7 @@ describe('Exchange data manager - unit', async function () {
         await checkDataEqual((await exchangeData.getCachedDecryptionDataKeyByAccessControlHash([hash]))[hash], data)
       }
       if (data.exchangeData.delegator === selfId) {
-        await checkDataEqual(await exchangeData.getOrCreateEncryptionDataTo(data.exchangeData.delegate, false), data)
+        await checkDataEqual(await exchangeData.getOrCreateEncryptionDataTo(data.exchangeData.delegate), data)
       }
       await checkDataEqual((await exchangeData.getDecryptionDataKeyByIds([data.exchangeData.id!], true))[data.exchangeData.id!], data)
       exchangeDataApi.compareCallCountFromBaseline(apiCallsBaseline, {
@@ -594,7 +594,7 @@ describe('Exchange data manager - unit', async function () {
         expect(Object.keys(await exchangeData.getCachedDecryptionDataKeyByAccessControlHash([hash]))).to.have.length(0)
       }
       if (data.exchangeData.delegator === selfId) {
-        await checkDataEqual(await exchangeData.getOrCreateEncryptionDataTo(data.exchangeData.delegate, false), data)
+        await checkDataEqual(await exchangeData.getOrCreateEncryptionDataTo(data.exchangeData.delegate), data)
         exchangeDataApi.compareCallCountFromBaseline(apiCallsBaseline, {
           getExchangeDataByIds: 0,
           createExchangeData: 0,
@@ -614,8 +614,8 @@ describe('Exchange data manager - unit', async function () {
       }
     }
 
-    const createdBySelf1 = await exchangeData.getOrCreateEncryptionDataTo(selfId, false)
-    const createdBySelf2 = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
+    const createdBySelf1 = await exchangeData.getOrCreateEncryptionDataTo(selfId)
+    const createdBySelf2 = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
     const createdByOther1 = await createDataFromRandomToSelf() // Not automatically cached: created by someone else
     const createdByOther2 = await createDataFromRandomToSelf() // Not automatically cached: created by someone else
     // noinspection DuplicatedCode
@@ -650,7 +650,7 @@ describe('Exchange data manager - unit', async function () {
 
   it('implementation with unlimited cache should preload all existing exchange data on creation', async function () {
     await initialiseComponents(true)
-    const createdBySelf = await exchangeData.getOrCreateEncryptionDataTo(selfId, false)
+    const createdBySelf = await exchangeData.getOrCreateEncryptionDataTo(selfId)
     const createdByOther = await createDataFromRandomToSelf()
     const recreatedExchangeData = await initialiseExchangeDataManagerForCurrentDataOwner(
       baseExchangeData,
@@ -696,8 +696,8 @@ describe('Exchange data manager - e2e', async function () {
   it('give access back should not invalidate existing and valid exchange data', async function () {
     const hcp1Details = await createNewHcpApi(env)
     const hcp2Details = await createNewHcpApi(env)
-    const ed1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp2Details.credentials.dataOwnerId, false)
-    const ed2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp1Details.credentials.dataOwnerId, false)
+    const ed1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp2Details.credentials.dataOwnerId)
+    const ed2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp1Details.credentials.dataOwnerId)
     await hcp1Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
     await hcp2Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
     const newKeyPair = await hcp1Details.api.cryptoApi.primitives.RSA.generateKeyPair(ShaVersion.Sha256)
@@ -710,8 +710,8 @@ describe('Exchange data manager - e2e', async function () {
     await hcp1Details.api.cryptoApi.exchangeData.giveAccessBackTo(hcp2Details.credentials.dataOwnerId, exportedPub)
     await hcp1Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
     await hcp2Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
-    const updatedEd1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp2Details.credentials.dataOwnerId, false)
-    const updatedEd2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp1Details.credentials.dataOwnerId, false)
+    const updatedEd1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp2Details.credentials.dataOwnerId)
+    const updatedEd2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp1Details.credentials.dataOwnerId)
     expect(updatedEd1to2.exchangeData.id).to.equal(ed1to2.exchangeData.id)
     expect(Object.keys(updatedEd2to1.exchangeData.exchangeKey).length).to.be.greaterThan(Object.keys(ed2to1.exchangeData.exchangeKey).length)
     expect(Object.keys(updatedEd2to1.exchangeData.exchangeKey).length).to.equal(Object.keys(updatedEd2to1.exchangeData.accessControlSecret).length)
@@ -725,8 +725,8 @@ describe('Exchange data manager - e2e', async function () {
   it('invalid exchange data should not be re-validated by give access back', async function () {
     const hcp1Details = await createNewHcpApi(env)
     const hcp2Details = await createNewHcpApi(env)
-    const ed1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp2Details.credentials.dataOwnerId, false)
-    const ed2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp1Details.credentials.dataOwnerId, false)
+    const ed1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp2Details.credentials.dataOwnerId)
+    const ed2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp1Details.credentials.dataOwnerId)
     await hcp1Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
     await hcp2Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
     const exchangeDataApi = new IccExchangeDataApi(env.iCureUrl, {}, hcp1Details.api.authApi.authenticationProvider, fetch)
@@ -763,8 +763,8 @@ describe('Exchange data manager - e2e', async function () {
     await hcp1Details.api.cryptoApi.exchangeData.giveAccessBackTo(hcp2Details.credentials.dataOwnerId, exportedPub)
     await hcp1Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
     await hcp2Details.api.cryptoApi.exchangeData.clearOrRepopulateCache()
-    const updatedEd1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp2Details.credentials.dataOwnerId, false)
-    const updatedEd2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp1Details.credentials.dataOwnerId, false)
+    const updatedEd1to2 = await hcp1Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp2Details.credentials.dataOwnerId)
+    const updatedEd2to1 = await hcp2Details.api.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcp1Details.credentials.dataOwnerId)
     expect(updatedEd1to2.exchangeData.id).to.not.equal(ed1to2.exchangeData.id)
     expect(updatedEd2to1.exchangeData.id).to.not.equal(ed2to1.exchangeData.id)
     const decData1to2 = (await hcp1Details.api.cryptoApi.exchangeData.getDecryptionDataKeyByIds([ed1to2.exchangeData.id!], true))[

--- a/test/icc-x-api/crypto/secure-delegations-manager-test.ts
+++ b/test/icc-x-api/crypto/secure-delegations-manager-test.ts
@@ -201,7 +201,7 @@ describe('Secure delegations manager', async function () {
       await initialiseComponents(false, false)
       const canonicalSfk = primitives.randomUuid()
       const aliasSfk = primitives.randomUuid()
-      const exchangeDataInfo = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
+      const exchangeDataInfo = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
       const canonicalKey = await accessControlSecretUtils.secureDelegationKeyFor(
         exchangeDataInfo.accessControlSecret,
         EntityWithDelegationTypeName.Patient
@@ -271,7 +271,7 @@ describe('Secure delegations manager', async function () {
   it('should return undefined for existing secure delegations if it contains all entries.', async function () {
     await initialiseComponents(false, false)
     const canonicalSfk = primitives.randomUuid()
-    const exchangeDataInfo = await exchangeData.getOrCreateEncryptionDataTo(delegateId, false)
+    const exchangeDataInfo = await exchangeData.getOrCreateEncryptionDataTo(delegateId)
     const canonicalKey = await accessControlSecretUtils.secureDelegationKeyFor(
       exchangeDataInfo.accessControlSecret,
       EntityWithDelegationTypeName.Patient

--- a/test/icc-x-api/icc-hcparty-x-api-test.ts
+++ b/test/icc-x-api/icc-hcparty-x-api-test.ts
@@ -5,6 +5,7 @@ import { getEnvironmentInitializer, hcp1Username, setLocalStorage, TestUtils } f
 import initApi = TestUtils.initApi
 import { expect } from 'chai'
 import { getEnvVariables, TestVars } from '@icure/test-setup/types'
+import { HealthcareParty } from '../../icc-api/model/HealthcareParty'
 
 setLocalStorage(fetch)
 let env: TestVars
@@ -22,25 +23,8 @@ describe('icc-hcparty-x-api Tests', () => {
 
     const user = await userApi.getCurrentUser()
 
-    let promiseResolves: boolean
-    try {
-      await hcpApi.getHealthcareParties({ ids: [user.id!, user.healthcarePartyId!] })
-      promiseResolves = true
-    } catch {
-      promiseResolves = false
-    }
-
-    await hcpApi.getHealthcareParties({ ids: [user.id!, user.healthcarePartyId!] }).then(
-      (_) => {
-        throw new Error('This promise should not resolve')
-      },
-      (e) => {
-        expect(JSON.parse(e.message)['message']).to.be.equal(
-          `Object with ID ${user.id!} is not of expected type org.taktik.icure.entities.HealthcareParty but of type org.taktik.icure.entities.User`
-        )
-      }
-    )
-    expect(promiseResolves).to.be.false
+    const retrievedBoth: HealthcareParty[] = await hcpApi.getHealthcareParties({ ids: [user.id!, user.healthcarePartyId!] })
+    expect(retrievedBoth.map((x) => x.id)).to.have.members([user.healthcarePartyId])
 
     const hcp = await hcpApi.getHealthcareParty(user.healthcarePartyId!)
     expect(hcp.id).to.be.equal(user.healthcarePartyId!)

--- a/test/icc-x-api/keyless-api.ts
+++ b/test/icc-x-api/keyless-api.ts
@@ -1,0 +1,157 @@
+import 'isomorphic-fetch'
+
+import { before } from 'mocha'
+import { createNewHcpApi, createNewKeylessApi, getEnvironmentInitializer, setLocalStorage, TestUtils } from '../utils/test_utils'
+import { IcureApi, SecretIdUseOption, ShaVersion } from '../../icc-x-api'
+import { webcrypto } from 'crypto'
+import { expect } from 'chai'
+import { getEnvVariables, TestVars } from '@icure/test-setup/types'
+import { Patient } from '../../icc-api/model/Patient'
+import { CalendarItem } from '../../icc-api/model/CalendarItem'
+import { TestKeyStorage } from '../utils/TestStorage'
+import { TestCryptoStrategies } from '../utils/TestCryptoStrategies'
+import { KeylessCryptoStrategies } from '../utils/KeylessCryptoStrategies'
+
+setLocalStorage(fetch)
+let env: TestVars
+
+describe('Keyless api Tests', () => {
+  before(async function () {
+    this.timeout(600000)
+    const initializer = await getEnvironmentInitializer()
+    env = await initializer.execute(getEnvVariables())
+  })
+
+  const calendarItemTitle = 'Encrypted title'
+
+  async function initializeTestData() {
+    const { api: patientApi, credentials: patientCredentials } = await createNewKeylessApi(env)
+    const patientUser = await patientApi.userApi.getCurrentUser()
+    const patient = (await patientApi.dataOwnerApi.getCurrentDataOwner()).dataOwner as Patient
+    const { api: hcpApi, credentials: hcpDetails, user: hcpUser } = await createNewHcpApi(env)
+    const exchangeData = await patientApi.cryptoApi.keylessCreateExchangeDataTo(hcpDetails.dataOwnerId)
+    const createdCalendarItem = await patientApi.calendarItemApi.createCalendarItemWithHcParty(
+      patientUser,
+      await patientApi.calendarItemApi.newInstancePatient(
+        patientUser,
+        patient,
+        { title: calendarItemTitle },
+        {
+          sfkOption: SecretIdUseOption.UseNone,
+          alternateRootDelegation: hcpDetails.dataOwnerId,
+        }
+      )
+    )
+    expect(createdCalendarItem.title).to.equal(calendarItemTitle)
+    return {
+      patientApi,
+      patientCredentials,
+      patientUser,
+      patient,
+      hcpApi,
+      hcpDetails,
+      hcpUser,
+      exchangeData,
+      createdCalendarItem,
+    }
+  }
+
+  it('Keyless api should allow creation of data and retrieval by delegator and delegate', async () => {
+    const { patientApi, patientUser, patient, hcpApi, hcpUser, createdCalendarItem } = await initializeTestData()
+
+    const retrievedByPatient: CalendarItem = await patientApi.calendarItemApi.getCalendarItemWithUser(patientUser, createdCalendarItem.id)
+    expect(retrievedByPatient.title).to.equal(calendarItemTitle)
+    expect(await patientApi.calendarItemApi.decryptPatientIdOf(retrievedByPatient)).to.have.members([patient.id])
+    const retrievedByHcp: CalendarItem = await hcpApi.calendarItemApi.getCalendarItemWithUser(hcpUser, createdCalendarItem.id)
+    expect(retrievedByHcp.title).to.equal(calendarItemTitle)
+    expect(await hcpApi.calendarItemApi.decryptPatientIdOf(retrievedByHcp)).to.have.members([patient.id])
+  })
+
+  it('Keyless api should allow retrieval in new instance after exchange data injection', async () => {
+    const { patientCredentials, patientUser, patient, exchangeData, createdCalendarItem } = await initializeTestData()
+
+    const newPatientApi = await IcureApi.initialise(env.iCureUrl, patientCredentials, new KeylessCryptoStrategies(), webcrypto as any, fetch, {})
+    await newPatientApi.calendarItemApi.getCalendarItemWithUser(patientUser, createdCalendarItem.id).then(
+      () => {
+        throw new Error('Get before injection for anonymous user should not work')
+      },
+      () => {
+        /* ok, expected */
+      }
+    )
+    await newPatientApi.cryptoApi.injectExchangeData([{ ...exchangeData, verified: false }], false)
+    const retrievedByNewApi: CalendarItem = await newPatientApi.calendarItemApi.getCalendarItemWithUser(patientUser, createdCalendarItem.id)
+    expect(retrievedByNewApi.title).to.equal(calendarItemTitle)
+    expect(await newPatientApi.calendarItemApi.decryptPatientIdOf(retrievedByNewApi)).to.have.members([patient.id])
+  })
+
+  it('Should allow re-encryption of exchange data as unverified on injection', async () => {
+    const { patientApi, patientCredentials, patientUser, patient, hcpDetails, exchangeData, createdCalendarItem } = await initializeTestData()
+
+    const keyStorage = new TestKeyStorage()
+    const newKey = await patientApi.cryptoApi.primitives.RSA.generateKeyPair(ShaVersion.Sha256)
+    const newPatientApiWithKeyAndInjected = await IcureApi.initialise(
+      env.iCureUrl,
+      patientCredentials,
+      new TestCryptoStrategies(newKey),
+      webcrypto as any,
+      fetch,
+      {
+        keyStorage,
+        injectExchangeData: {
+          details: [{ ...exchangeData, verified: false }],
+          reEncryptWithOwnKeys: true,
+        },
+      }
+    )
+    expect(
+      (await newPatientApiWithKeyAndInjected.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcpDetails.dataOwnerId)).exchangeData.id ==
+        exchangeData.exchangeDataId
+    ).to.be.false
+    const newPatientApiWithKey = await IcureApi.initialise(env.iCureUrl, patientCredentials, new TestCryptoStrategies(), webcrypto as any, fetch, {
+      keyStorage,
+    })
+    const retrievedByNewApi: CalendarItem = await newPatientApiWithKey.calendarItemApi.getCalendarItemWithUser(patientUser, createdCalendarItem.id)
+    expect(retrievedByNewApi.title).to.equal(calendarItemTitle)
+    expect(await newPatientApiWithKey.calendarItemApi.decryptPatientIdOf(retrievedByNewApi)).to.have.members([patient.id])
+    expect(
+      (await newPatientApiWithKey.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcpDetails.dataOwnerId)).exchangeData.id ==
+        exchangeData.exchangeDataId
+    ).to.be.false
+  })
+
+  it('Should allow re-encryption of exchange data as verified on injection', async () => {
+    const { patientApi, patientCredentials, patientUser, patient, hcpDetails, exchangeData, createdCalendarItem } = await initializeTestData()
+
+    const keyStorage = new TestKeyStorage()
+    const newKey = await patientApi.cryptoApi.primitives.RSA.generateKeyPair(ShaVersion.Sha256)
+    const newPatientApiWithKeyAndInjected = await IcureApi.initialise(
+      env.iCureUrl,
+      patientCredentials,
+      new TestCryptoStrategies(newKey),
+      webcrypto as any,
+      fetch,
+      {
+        keyStorage,
+        injectExchangeData: {
+          details: [{ ...exchangeData, verified: true }],
+          reEncryptWithOwnKeys: true,
+        },
+      }
+    )
+    expect(
+      (await newPatientApiWithKeyAndInjected.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcpDetails.dataOwnerId)).exchangeData.id ==
+        exchangeData.exchangeDataId
+    ).to.be.true
+    const newPatientApiWithKey = await IcureApi.initialise(env.iCureUrl, patientCredentials, new TestCryptoStrategies(), webcrypto as any, fetch, {
+      keyStorage,
+    })
+    expect(
+      (await newPatientApiWithKey.cryptoApi.exchangeData.getOrCreateEncryptionDataTo(hcpDetails.dataOwnerId)).exchangeData.id ==
+        exchangeData.exchangeDataId
+    ).to.be.true
+    const retrievedByNewApi: CalendarItem = await newPatientApiWithKey.calendarItemApi.getCalendarItemWithUser(patientUser, createdCalendarItem.id)
+    expect(retrievedByNewApi.title).to.equal(calendarItemTitle)
+    expect(await newPatientApiWithKey.calendarItemApi.decryptPatientIdOf(retrievedByNewApi)).to.have.members([patient.id])
+  })
+})

--- a/test/utils/FakeExchangeDataManager.ts
+++ b/test/utils/FakeExchangeDataManager.ts
@@ -4,6 +4,7 @@ import { ExchangeData } from '../../icc-api/model/internal/ExchangeData'
 import { expect } from 'chai'
 import { BaseExchangeDataManager } from '../../icc-x-api/crypto/BaseExchangeDataManager'
 import { CryptoPrimitives } from '../../icc-x-api'
+import { id } from 'date-fns/locale'
 
 export class FakeDecryptionExchangeDataManager implements ExchangeDataManager {
   constructor(private readonly cryptoPrimitives: CryptoPrimitives) {}
@@ -48,7 +49,9 @@ export class FakeDecryptionExchangeDataManager implements ExchangeDataManager {
     return res
   }
 
-  getOrCreateEncryptionDataTo(delegateId: string): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey }> {
+  getOrCreateEncryptionDataTo(
+    delegateId: string
+  ): Promise<{ exchangeData: ExchangeData; accessControlSecret: string; exchangeKey: CryptoKey; sharedSignatureKey: CryptoKey }> {
     throw new Error('This method should not be used with this fake exchange data manager: only retrieval decryption data is supported')
   }
 
@@ -86,6 +89,19 @@ export class FakeDecryptionExchangeDataManager implements ExchangeDataManager {
   }
 
   get base(): BaseExchangeDataManager {
+    throw new Error('This method should not be used with this fake exchange data manager: only retrieval decryption data is supported')
+  }
+
+  injectDecryptedExchangeData(
+    exchangeDataDetails: {
+      exchangeDataId: string
+      accessControlSecret: ArrayBuffer
+      exchangeKey: ArrayBuffer
+      sharedSignatureKey: ArrayBuffer
+      verified: boolean
+    }[],
+    reEncryptWithOwnKeys: boolean
+  ): Promise<void> {
     throw new Error('This method should not be used with this fake exchange data manager: only retrieval decryption data is supported')
   }
 }

--- a/test/utils/KeylessCryptoStrategies.ts
+++ b/test/utils/KeylessCryptoStrategies.ts
@@ -1,0 +1,37 @@
+import { CryptoPrimitives, CryptoStrategies, KeyPair } from '../../icc-x-api'
+import { CryptoActorStubWithType } from '../../icc-api/model/CryptoActorStub'
+import { DataOwnerTypeEnum } from '../../icc-api/model/DataOwnerTypeEnum'
+import { DataOwnerWithType } from '../../icc-api/model/DataOwnerWithType'
+
+export class KeylessCryptoStrategies implements CryptoStrategies {
+  requestedKey: boolean = false
+
+  dataOwnerRequiresAnonymousDelegation(dataOwner: CryptoActorStubWithType): boolean {
+    return dataOwner.type != DataOwnerTypeEnum.Hcp
+  }
+
+  generateNewKeyForDataOwner(): Promise<KeyPair<CryptoKey> | boolean | 'keyless'> {
+    this.requestedKey = true
+    return Promise.resolve('keyless')
+  }
+
+  recoverAndVerifySelfHierarchyKeys(
+    keysData: {
+      dataOwner: DataOwnerWithType
+      unknownKeys: string[]
+      unavailableKeys: string[]
+    }[]
+  ): Promise<{
+    [p: string]: { recoveredKeys: { [p: string]: KeyPair<CryptoKey> }; keyAuthenticity: { [p: string]: boolean } }
+  }> {
+    const res: {
+      [p: string]: { recoveredKeys: { [p: string]: KeyPair<CryptoKey> }; keyAuthenticity: { [p: string]: boolean } }
+    } = {}
+    keysData.forEach((x) => (res[x.dataOwner.dataOwner.id!] = { recoveredKeys: {}, keyAuthenticity: {} }))
+    return Promise.resolve(res)
+  }
+
+  verifyDelegatePublicKeys(delegate: CryptoActorStubWithType, publicKeys: string[], cryptoPrimitives: CryptoPrimitives): Promise<string[]> {
+    return Promise.resolve(publicKeys)
+  }
+}

--- a/test/utils/test_utils.ts
+++ b/test/utils/test_utils.ts
@@ -1,22 +1,22 @@
 import {
-  BasicApis,
   BasicAuthenticationProvider,
   CryptoPrimitives,
-  WebCryptoPrimitives,
+  CryptoStrategies,
   hex2ua,
   IcureApi,
   IcureApiOptions,
+  IcureBasicApi,
+  KeyPair,
   retry,
-  RSAUtils,
   RSAUtilsImpl,
   ShaVersion,
   ua2hex,
-  IcureBasicApi,
+  WebCryptoPrimitives,
 } from '../../icc-x-api'
 import { tmpdir } from 'os'
 import { TextDecoder, TextEncoder } from 'util'
 import { v4 as uuid } from 'uuid'
-import { webcrypto } from 'crypto'
+import { randomUUID, webcrypto } from 'crypto'
 import { TestApi } from './TestApi'
 import { IcureApi as TestSetupApi } from '@icure/apiV7'
 import { testStorageWithKeys } from './TestStorage'
@@ -30,6 +30,12 @@ import { createPatientUser } from '@icure/test-setup/creation'
 import { IccUserApi } from '../../icc-api'
 import { Context, describe, Suite, Test } from 'mocha'
 import { Group } from '../../icc-api/model/Group'
+import { Patient } from '../../icc-api/model/Patient'
+import { CryptoActorStubWithType } from '../../icc-api/model/CryptoActorStub'
+import { DataOwnerTypeEnum } from '../../icc-api/model/DataOwnerTypeEnum'
+import { DataOwnerWithType } from '../../icc-api/model/DataOwnerWithType'
+import { KeyPairRecoverer } from '../../icc-x-api/crypto/KeyPairRecoverer'
+import { KeylessCryptoStrategies } from './KeylessCryptoStrategies'
 
 export function getTempEmail(): string {
   return `${uuid().substring(0, 8)}@icure.com`
@@ -201,6 +207,33 @@ export async function createNewPatientApi(env: TestVars): Promise<{
     }
   )
   return { api, credentials, user: await api.userApi.getCurrentUser() }
+}
+
+export async function createNewKeylessApi(env: TestVars): Promise<{
+  api: IcureApi
+  credentials: { username: string; password: string }
+}> {
+  const initialisationApi = await IcureBasicApi.initialise(env.iCureUrl, { username: env.masterHcp!.user, password: env.masterHcp!.password }, fetch)
+  const login = `${randomUUID()}@test.icure.com`
+  const password = randomUUID()
+  const patient = new Patient({
+    id: randomUUID(),
+    firstName: 'Gino',
+    lastName: 'Pino',
+  })
+  const user = new User({
+    id: randomUUID(),
+    login,
+    passwordHash: password,
+    patientId: patient.id,
+  })
+  await initialisationApi.userApi.createUser(user)
+  await initialisationApi.patientApi.createPatient(patient)
+  const credentials = { username: login, password }
+  const cryptoStrategies = new KeylessCryptoStrategies()
+  const api = await IcureApi.initialise(env.iCureUrl, credentials, cryptoStrategies, webcrypto as any, fetch, {})
+  if (!cryptoStrategies.requestedKey) throw new Error('Illegal state: did not request key')
+  return { api, credentials }
 }
 
 /**


### PR DESCRIPTION
New mode of use of the API that allows the user to create data without having to handle proper key management and recovery. Keyless API mode currently is exclusively available to anonymous data owners.

[Refer to tests for code sample](https://github.com/icure/icure-typescript-sdk/blob/b3f1c36cdf1537e1b11576b964fca50059c75ee2/test/icc-x-api/keyless-api.ts)

## Initialization

Initialized by returning `"keyless"` in the `CryptoStrategies.generateNewKeyForDataOwner`

## New data creation

The first time a user initializes an instance of keyless api, before creating any kind of encrypted entity they must forcefully initialize new exchange data to all data owners that will be delegate in the data you plan to create. This can be done through the `keylessCreateExchangeDataTo` method of the crypto API. Note that it is not possible to create data in kelyess mode to yourself or to another user that has no public key setup.

When using the `newInstance` method in keyless mode you will also need to provide one of the delegates ids as value for `alternateRootDelegation`. This is because normally when creating new data a root delegation `self->self` is created, however, since in keyless mode it is impossible to create exchange data `self->self` the root delegation must be a delegation `self->other`.

## Access data from previous instances

In future instances of the keyless api the result of the `keylessCreateExchangeDataTo` method can be passed to the `injectExchangeData` api options, or to the `injectExchangeData` method of the crypto api to reuse the already created exchange data. Injecting exchange data created by a previous instance of the keyless api allows accessing the data created by that instance.

## Switch to standard api

If you want to allow your users to switch to standard apis (with proper personal keypairs and key management and recovery support) you can ask for re-encryption of the exchange data with the current data owners keys when injecting the exchange data to the standard api. This allows future instances (with access to the current user keypair) to use the provided exchange data without re-injection.

## Notes

### Compatibility with previous api versions

Exchange data created in keyless mode and encrypted data created with them require at least version 8.1.9 of @icure/api and version 0.1.233 of kraken-lite

Previous version will give errors when trying to decrypt data created in keyless mode

### Verified injected exchange data

When injecting exchange data you can specify if it should be treated as verified. Since the data was created in keyless mode it is not possible for the SDK to directly verify the exchange data.

Reminder: verified exchange data can be used for the creation of new entities; unverified exchange data is used only for decryption of existing entities.

When injecting exchange data you should choose how to treat it depending on the channel from which it was obtained and on the intended use.

For example if your application provides the user with a QR code generated fully on the client side for reinjection of the exchange data the process is generally safe. If instead you send the exchange data via email the process is not entirely safe, as an attacker could pose as your service to trick the user into injecting exchange data that is actually controlled by the attacker.

In some situations it could still be safe to consider as verified exchange data sent through unsecure channels. For example, if you are injecting the exchange data into an application that will use only to create data that is not extremely sensitive (such as appointments) you could still decide to consider it as verified. This has the advantage of reducing the proliferation of exchange data, which has positive effects on client-side caching. However, if you are planning to create more sensitive data (upload of medical files), or you're going to re-encrypt the exchange data for a switch to non-keyless api you should mark as verified only exchange data coming from secure sources.

The general tradeoff is that injecting the data as verified could help improve performances in the long run, but if the data comes from unsecure sources you may damage the confidentiality of the data.

### Injection during initialization or after

When possible you should always prefer to inject the exchange data during initialization of the api (through the api options). This can help to reduce the proliferation of exchange data, contributing to better performances in the long run.