### PR TITLE
Make document and message encryptable

### DIFF
--- a/icc-api/api/IccClassificationApi.ts
+++ b/icc-api/api/IccClassificationApi.ts
@@ -11,17 +11,13 @@
  */
 import { XHR } from './XHR'
 import { Classification } from '../model/Classification'
-import { Delegation } from '../model/Delegation'
 import { DocIdentifier } from '../model/DocIdentifier'
-import { IcureStub } from '../model/IcureStub'
 import { AuthenticationProvider, NoAuthenticationProvider } from '../../icc-x-api/auth/AuthenticationProvider'
 import { iccRestApiPath } from './IccRestApiPath'
-import { EntityShareOrMetadataUpdateRequest } from '../model/requests/EntityShareOrMetadataUpdateRequest'
 import { EntityBulkShareResult } from '../model/requests/EntityBulkShareResult'
 import { MinimalEntityBulkShareResult } from '../model/requests/MinimalEntityBulkShareResult'
 import { ListOfIds } from '../model/ListOfIds'
 import { BulkShareOrUpdateMetadataParams } from '../model/requests/BulkShareOrUpdateMetadataParams'
-import { PaginatedListClassification } from '../model/PaginatedListClassification'
 
 export class IccClassificationApi {
   host: string
@@ -176,6 +172,18 @@ export class IccClassificationApi {
     let headers = await this.headers
     return XHR.sendCommand('GET', _url, headers, _body, this.fetchImpl, undefined, this.authenticationProvider.getAuthService())
       .then((doc) => new Classification(doc.body as JSON))
+      .catch((err) => this.handleError(err))
+  }
+
+  async getClassifications(body?: ListOfIds): Promise<Array<Classification>> {
+    let _body = null
+    _body = body
+
+    const _url = this.host + `/classification/byIds` + '?ts=' + new Date().getTime()
+    let headers = await this.headers
+    headers = headers.filter((h) => h.header !== 'Content-Type').concat(new XHR.Header('Content-Type', 'application/json'))
+    return XHR.sendCommand('POST', _url, headers, _body, this.fetchImpl, undefined, this.authenticationProvider.getAuthService())
+      .then((doc) => (doc.body as Array<JSON>).map((it) => new Classification(it)))
       .catch((err) => this.handleError(err))
   }
 

--- a/icc-api/api/IccMessageApi.ts
+++ b/icc-api/api/IccMessageApi.ts
@@ -70,20 +70,6 @@ export class IccMessageApi {
   }
 
   /**
-   *
-   * @summary Creates a message
-   * @param body
-   */
-  async createMessageInTopic(body?: Message): Promise<Message> {
-    const _url = this.host + `/message/topic` + '?ts=' + new Date().getTime()
-    let headers = await this.headers
-    headers = headers.filter((h) => h.header !== 'Content-Type').concat(new XHR.Header('Content-Type', 'application/json'))
-    return XHR.sendCommand('POST', _url, headers, body, this.fetchImpl, undefined, this.authenticationProvider.getAuthService())
-      .then((doc) => new Message(doc.body as JSON))
-      .catch((err) => this.handleError(err))
-  }
-
-  /**
    * @summary Deletes a batch of messages.
    *
    * @param messageIds a ListOfIds containing the ids of the messages to delete.

--- a/icc-x-api/icc-bekmehr-x-api.ts
+++ b/icc-x-api/icc-bekmehr-x-api.ts
@@ -104,10 +104,8 @@ export class IccBekmehrXApi extends IccBekmehrApi {
             .then((res) => send('decryptResponse', msg.uuid, res))
         } else if (msg.type === 'DocumentDto') {
           that.documentApi
-            .decrypt(
-              healthcarePartyId,
-              msg.body.map((d: JSON) => new Document(d))
-            )
+            .decrypt(msg.body.map((d: JSON) => new Document(d)))
+            .then((res) => res.map((x) => x.entity))
             .then((res) =>
               patchers
                 .filter((p) => p.type === 'DocumentDto')

--- a/icc-x-api/icc-document-x-api.ts
+++ b/icc-x-api/icc-document-x-api.ts
@@ -13,10 +13,11 @@ import { ShareMetadataBehaviour } from './crypto/ShareMetadataBehaviour'
 import { ShareResult } from './utils/ShareResult'
 import { EntityShareRequest } from '../icc-api/model/requests/EntityShareRequest'
 import { EncryptedEntityXApi } from './basexapi/EncryptedEntityXApi'
-import { EntityWithDelegationTypeName } from './utils'
+import { EncryptedFieldsManifest, EntityWithDelegationTypeName, parseEncryptedFields } from './utils'
 import AccessLevelEnum = SecureDelegation.AccessLevelEnum
 import RequestedPermissionEnum = EntityShareRequest.RequestedPermissionEnum
 import { SecretIdUseOption } from './crypto/SecretIdUseOption'
+import { ListOfIds, PaginatedListDocument, PaginatedListMessage } from '../icc-api/model/models'
 
 // noinspection JSUnusedGlobalSymbols
 export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXApi<models.Document> {
@@ -553,6 +554,7 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
   }
   dataOwnerApi: IccDataOwnerXApi
   authenticationProvider: AuthenticationProvider
+  private readonly encryptedFields: EncryptedFieldsManifest
 
   constructor(
     host: string,
@@ -562,6 +564,7 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
     dataOwnerApi: IccDataOwnerXApi,
     private readonly autofillAuthor: boolean,
     authenticationProvider: AuthenticationProvider = new NoAuthenticationProvider(),
+    encryptedKeys: Array<string> = [],
     fetchImpl: (input: RequestInfo, init?: RequestInit) => Promise<Response> = typeof window !== 'undefined'
       ? window.fetch
       : typeof self !== 'undefined'
@@ -572,6 +575,7 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
     this.fetchImpl = fetchImpl
     this.authenticationProvider = authenticationProvider
     this.dataOwnerApi = dataOwnerApi
+    this.encryptedFields = parseEncryptedFields(encryptedKeys, 'Document.')
   }
 
   override get headers(): Promise<Array<XHR.Header>> {
@@ -650,16 +654,6 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
 
   // noinspection JSUnusedGlobalSymbols
   /**
-   * @deprecated use {@link findIdsByMessage} instead.
-   */
-  async findByMessage(hcpartyId: string, message: models.Message) {
-    const extractedKeys = await this.crypto.xapi.secretIdsOf({ entity: message, type: EntityWithDelegationTypeName.Message }, hcpartyId)
-    const topmostParentId = (await this.dataOwnerApi.getCurrentDataOwnerHierarchyIds())[0]
-    let documents: Array<models.Document> = await this.findDocumentsByHCPartyPatientForeignKeys(topmostParentId, _.uniq(extractedKeys))
-    return await this.decrypt(hcpartyId, documents)
-  }
-
-  /**
    * Same as {@link findByMessage} but it will only return the ids of the contacts. It can also filter the documents where Document.created is between
    * startDate and endDate in ascending or descending order by that field. (default: ascending).
    */
@@ -669,52 +663,19 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
     return this.findDocumentIdsByDataOwnerSecretForeignKey(topmostParentId, _.uniq(extractedKeys), startDate, endDate, descending)
   }
 
-  // Note: this is only for dealing with legacy documents: new document are not encrypted, only their attachments are
-  async decrypt(hcpartyId: string, documents: Array<models.Document>): Promise<Array<models.Document>> {
-    const res: models.Document[] = []
-    for (const document of documents) {
-      const keys = await this.crypto.xapi.encryptionKeysOf({ entity: document, type: EntityWithDelegationTypeName.Document }, undefined)
-      if (!keys.length) {
-        console.log('Cannot decrypt document', document.id)
-        res.push(document)
-      } else if (keys.length && (document.encryptedSelf || document.encryptedAttachment)) {
-        const key = await this.crypto.primitives.AES.importKey('raw', hex2ua(keys[0]))
-        res.push(
-          await Promise.all([
-            document.encryptedSelf
-              ? new Promise((resolve: (value: ArrayBuffer | null) => any) => {
-                  this.crypto.primitives.AES.decrypt(key, string2ua(a2b(document.encryptedSelf!))).then(resolve, () => {
-                    console.log('Cannot decrypt document', document.id)
-                    resolve(null)
-                  })
-                })
-              : Promise.resolve(null),
-            document.encryptedAttachment
-              ? new Promise((resolve: (value: ArrayBuffer | null) => any) => {
-                  this.crypto.primitives.AES.decrypt(key, document.encryptedAttachment!).then(resolve, () => {
-                    console.log('Cannot decrypt document', document.id)
-                    resolve(null)
-                  })
-                })
-              : Promise.resolve(null),
-          ]).then((decrypted: [ArrayBuffer | null, ArrayBuffer | null]) => {
-            let updatedDocument = { ...document }
-            if (decrypted) {
-              if (decrypted[0]) {
-                updatedDocument = _.extend(document, JSON.parse(ua2string(decrypted[0])))
-              }
-              if (decrypted[1]) {
-                updatedDocument.decryptedAttachment = decrypted[1]
-              }
-            }
-            return updatedDocument
-          })
-        )
-      } else {
-        res.push(document)
-      }
-    }
-    return res
+  async decrypt(documents: Array<models.Document>): Promise<{ entity: models.Document; decrypted: boolean }[]> {
+    return await this.crypto.xapi.tryDecryptEntities(documents, EntityWithDelegationTypeName.Document, (x) => new models.Document(x))
+  }
+
+  encrypt(documents: Array<models.Document>): Promise<Array<models.Document>> {
+    return this.crypto.xapi.tryEncryptEntities(
+      documents,
+      EntityWithDelegationTypeName.Document,
+      this.encryptedFields,
+      true,
+      false,
+      (x) => new models.Document(x)
+    )
   }
 
   //prettier-ignore
@@ -831,9 +792,11 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
   async encryptAndSetDocumentAttachment(document: models.Document, attachment: ArrayBuffer | Uint8Array, utis?: string[]): Promise<models.Document> {
     if (!document.rev) throw new Error('Cannot set attachment on document without rev')
     const { encryptedData, updatedEntity } = await this.crypto.xapi.encryptDataOf(document, EntityWithDelegationTypeName.Document, attachment, (d) =>
-      this.modifyDocument(d)
+      this.modifyDocumentWithUser(undefined, d)
     )
-    return await this.setMainDocumentAttachment(document.id!, updatedEntity?.rev ?? document.rev, encryptedData, utis, true)
+    return (
+      await this.decrypt([await super.setMainDocumentAttachment(document.id!, updatedEntity?.rev ?? document.rev, encryptedData, utis, true)])
+    )[0].entity
   }
 
   /**
@@ -846,7 +809,7 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
    */
   async setClearDocumentAttachment(document: models.Document, attachment: ArrayBuffer | Uint8Array, utis?: string[]): Promise<models.Document> {
     if (!document.rev) throw new Error('Cannot set attachment on document without rev')
-    return await this.setMainDocumentAttachment(document.id!, document.rev, attachment, utis, false)
+    return (await this.decrypt([await super.setMainDocumentAttachment(document.id!, document.rev, attachment, utis, false)]))[0].entity
   }
 
   /**
@@ -866,9 +829,13 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
   ): Promise<models.Document> {
     if (!document.rev) throw new Error('Cannot set attachment on document without rev')
     const { encryptedData, updatedEntity } = await this.crypto.xapi.encryptDataOf(document, EntityWithDelegationTypeName.Document, attachment, (d) =>
-      this.modifyDocument()
+      this.modifyDocumentWithUser(undefined, d)
     )
-    return await this.setSecondaryAttachment(document.id!, secondaryAttachmentKey, updatedEntity?.rev ?? document.rev!, encryptedData, utis, true)
+    return (
+      await this.decrypt([
+        await super.setSecondaryAttachment(document.id!, secondaryAttachmentKey, updatedEntity?.rev ?? document.rev!, encryptedData, utis, true),
+      ])
+    )[0].entity
   }
 
   /**
@@ -886,7 +853,8 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
     attachment: ArrayBuffer | Uint8Array,
     utis?: string[]
   ): Promise<models.Document> {
-    return await this.setSecondaryAttachment(document.id!, secondaryAttachmentKey, document.rev!, attachment, utis, false)
+    return (await this.decrypt([await super.setSecondaryAttachment(document.id!, secondaryAttachmentKey, document.rev!, attachment, utis, false)]))[0]
+      .entity
   }
 
   /**
@@ -920,7 +888,7 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
   ): Promise<{ data: ArrayBuffer; wasDecrypted: boolean }> {
     return await this.crypto.xapi.tryDecryptDataOf(
       { entity: document, type: EntityWithDelegationTypeName.Document },
-      await this.getRawMainDocumentAttachment(document.id!),
+      await super.getRawMainDocumentAttachment(document.id!),
       (x) => validator(x)
     )
   }
@@ -960,7 +928,7 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
   ): Promise<{ data: ArrayBuffer; wasDecrypted: boolean }> {
     return await this.crypto.xapi.tryDecryptDataOf(
       { entity: document, type: EntityWithDelegationTypeName.Document },
-      await this.getSecondaryAttachment(document.id!, secondaryAttachmentKey),
+      await super.getSecondaryAttachment(document.id!, secondaryAttachmentKey),
       (x) => validator(x)
     )
   }
@@ -1062,7 +1030,7 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
     const self = await this.dataOwnerApi.getCurrentDataOwnerId()
     // All entities should have an encryption key.
     const entityWithEncryptionKey = await this.crypto.xapi.ensureEncryptionKeysInitialised(document, EntityWithDelegationTypeName.Document)
-    const updatedEntity = entityWithEncryptionKey ? await this.modifyDocument(entityWithEncryptionKey) : document
+    const updatedEntity = entityWithEncryptionKey ? await this.modifyDocumentWithUser(undefined, entityWithEncryptionKey) : document
     return this.crypto.xapi
       .simpleShareOrUpdateEncryptedEntityMetadata(
         {
@@ -1080,9 +1048,9 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
             },
           ])
         ),
-        (x) => this.bulkShareDocument(x)
+        (x) => super.bulkShareDocument(x)
       )
-      .then((r) => r)
+      .then((r) => r.mapSuccessAsync(async (m) => (await this.decrypt([m]))[0].entity))
   }
 
   getDataOwnersWithAccessTo(
@@ -1100,5 +1068,184 @@ export class IccDocumentXApi extends IccDocumentApi implements EncryptedEntityXA
       { entity, type: EntityWithDelegationTypeName.Document },
       delegates
     )
+  }
+
+  private async decryptPage(page: PaginatedListDocument): Promise<PaginatedListDocument> {
+    return {
+      ...page,
+      rows: (await this.decrypt(page.rows ?? [])).map((x) => x.entity),
+    }
+  }
+
+  async createDocumentWithUser(user: models.User | undefined, body: models.Document): Promise<models.Document> {
+    return (await this.decrypt([await super.createDocument((await this.encrypt([body]))[0])]))[0].entity
+  }
+
+  async deleteAttachmentWithUser(user: models.User | undefined, documentId: string): Promise<models.Document> {
+    return (await this.decrypt([await super.deleteAttachment(documentId)]))[0].entity
+  }
+
+  /**
+   * @deprecated
+   */
+  async findByTypeHCPartyMessageSecretFKeysWithUser(
+    user: models.User | undefined,
+    documentTypeCode: string,
+    hcPartyId: string,
+    secretFKeys: string[]
+  ): Promise<Array<models.Document>> {
+    return (await this.decrypt(await super.findByTypeHCPartyMessageSecretFKeys(documentTypeCode, hcPartyId, secretFKeys))).map((x) => x.entity)
+  }
+
+  /**
+   * @deprecated
+   */
+  async findDocumentsByHCPartyPatientForeignKeysWithUser(
+    user: models.User | undefined,
+    hcPartyId: string,
+    secretFKeys: string[]
+  ): Promise<Array<models.Document>> {
+    return (await this.decrypt(await super.findDocumentsByHCPartyPatientForeignKeys(hcPartyId, secretFKeys))).map((x) => x.entity)
+  }
+
+  /**
+   * @deprecated
+   */
+  async findDocumentsByHCPartyPatientForeignKeyWithUser(
+    user: models.User | undefined,
+    hcPartyId: string,
+    secretFKey: string,
+    startKey?: string,
+    startDocumentId?: string,
+    limit?: number
+  ): Promise<PaginatedListDocument> {
+    return await this.decryptPage(await super.findDocumentsByHCPartyPatientForeignKey(hcPartyId, secretFKey, startKey, startDocumentId, limit))
+  }
+
+  async findWithoutDelegationWithUser(user: models.User | undefined, limit?: number): Promise<Array<models.Document>> {
+    return (await this.decrypt(await super.findWithoutDelegation(limit))).map((x) => x.entity)
+  }
+
+  async getDocumentWithUser(user: models.User | undefined, documentId: string): Promise<models.Document> {
+    return (await this.decrypt([await super.getDocument(documentId)]))[0].entity
+  }
+
+  async getDocumentByExternalUuidWithUser(user: models.User | undefined, externalUuid: string): Promise<models.Document> {
+    return (await this.decrypt([await super.getDocumentByExternalUuid(externalUuid)]))[0].entity
+  }
+
+  async getDocumentsWithUser(user: models.User | undefined, body?: ListOfIds): Promise<Array<models.Document>> {
+    return (await this.decrypt(await super.getDocuments(body))).map((x) => x.entity)
+  }
+
+  async getDocumentsByExternalUuidWithUser(user: models.User | undefined, externalUuid: string): Promise<Array<models.Document>> {
+    return (await this.decrypt(await super.getDocumentsByExternalUuid(externalUuid))).map((x) => x.entity)
+  }
+
+  async modifyDocumentWithUser(user: models.User | undefined, body: models.Document): Promise<models.Document> {
+    return (await this.decrypt([await super.modifyDocument((await this.encrypt([body]))[0])]))[0].entity
+  }
+
+  async modifyDocumentsWithUser(user: models.User | undefined, body: Array<models.Document>): Promise<Array<models.Document>> {
+    return (await this.decrypt(await super.modifyDocuments(await this.encrypt(body)))).map((x) => x.entity)
+  }
+
+  async setMainDocumentAttachmentWithUser(
+    user: models.User | undefined,
+    documentId: string,
+    documentRev: string,
+    body: Object,
+    utis?: Array<string>,
+    dataIsEncrypted?: boolean
+  ): Promise<models.Document> {
+    return (await this.decrypt([await super.setMainDocumentAttachment(documentId, documentRev, body, utis, dataIsEncrypted)]))[0].entity
+  }
+
+  async setSecondaryAttachmentWithUser(
+    user: models.User | undefined,
+    documentId: string,
+    key: string,
+    rev: string,
+    attachment: Object,
+    utis?: Array<string>,
+    dataIsEncrypted?: boolean
+  ): Promise<models.Document> {
+    return (await this.decrypt([await super.setSecondaryAttachment(documentId, key, rev, attachment, utis, dataIsEncrypted)]))[0].entity
+  }
+
+  async deleteSecondaryAttachmentWithUser(user: models.User | undefined, documentId: string, key: string, rev: string): Promise<models.Document> {
+    return (await this.decrypt([await super.deleteSecondaryAttachment(documentId, key, rev)]))[0].entity
+  }
+
+  createDocument(body?: models.Document): never {
+    throw new Error('Use withUser method')
+  }
+
+  deleteAttachment(documentId: string): never {
+    throw new Error('Use withUser method')
+  }
+
+  findByTypeHCPartyMessageSecretFKeys(documentTypeCode: string, hcPartyId: string, secretFKeys: string[]): never {
+    throw new Error('Use withUser method')
+  }
+
+  findDocumentsByHCPartyPatientForeignKeys(hcPartyId: string, secretFKeys: string[]): never {
+    throw new Error('Use withUser method')
+  }
+
+  findDocumentsByHCPartyPatientForeignKey(hcPartyId: string, secretFKey: string, startKey?: string, startDocumentId?: string, limit?: number): never {
+    throw new Error('Use withUser method')
+  }
+
+  findWithoutDelegation(limit?: number): never {
+    throw new Error('Use withUser method')
+  }
+
+  getDocument(documentId: string): never {
+    throw new Error('Use withUser method')
+  }
+
+  getDocumentByExternalUuid(externalUuid: string): never {
+    throw new Error('Use withUser method')
+  }
+
+  getDocuments(body?: ListOfIds): never {
+    throw new Error('Use withUser method')
+  }
+
+  getDocumentsByExternalUuid(externalUuid: string): never {
+    throw new Error('Use withUser method')
+  }
+
+  modifyDocument(body?: models.Document): never {
+    throw new Error('Use withUser method')
+  }
+
+  modifyDocuments(body?: Array<models.Document>): never {
+    throw new Error('Use withUser method')
+  }
+
+  setMainDocumentAttachment(documentId: string, documentRev: string, body: Object, utis?: Array<string>, dataIsEncrypted?: boolean): never {
+    throw new Error('Use withUser method')
+  }
+
+  setDocumentAttachmentBody(documentId: string, documentRev: string, enckeys?: null, body?: Object, utis?: string[]): never {
+    throw new Error('Use withUser method')
+  }
+
+  setDocumentAttachment(documentId: string, documentRev: string, enckeys?: null, body?: Object, utis?: string[]): never {
+    throw new Error('Use withUser method')
+  }
+
+  setDocumentAttachmentMulti(attachment: ArrayBuffer, documentRev: string, documentId: string, enckeys?: null): never {
+    throw new Error('Use withUser method')
+  }
+
+  setSecondaryAttachment(documentId: string, key: string, rev: string, attachment: Object, utis?: Array<string>, dataIsEncrypted?: boolean): never {
+    throw new Error('Use withUser method')
+  }
+
+  deleteSecondaryAttachment(documentId: string, key: string, rev: string): never {
+    throw new Error('Use withUser method')
   }
 }

--- a/icc-x-api/icc-message-x-api.ts
+++ b/icc-x-api/icc-message-x-api.ts
@@ -2,7 +2,7 @@ import { IccAuthApi, IccMessageApi } from '../icc-api'
 import { IccCryptoXApi } from './icc-crypto-x-api'
 
 import * as models from '../icc-api/model/models'
-import { Message, MessagesReadStatusUpdate, PaginatedListMessage, Patient, User } from '../icc-api/model/models'
+import { DocIdentifier, ListOfIds, Message, MessagesReadStatusUpdate, PaginatedListMessage, Patient, User } from '../icc-api/model/models'
 import { IccDataOwnerXApi } from './icc-data-owner-x-api'
 import { AuthenticationProvider, NoAuthenticationProvider } from './auth/AuthenticationProvider'
 import { SecureDelegation } from '../icc-api/model/SecureDelegation'
@@ -18,6 +18,8 @@ import { AbstractFilter } from './filters/filters'
 import { EncryptedFieldsManifest, EntityWithDelegationTypeName, parseEncryptedFields, subscribeToEntityEvents, SubscriptionOptions } from './utils'
 import { Connection, ConnectionImpl } from '../icc-api/model/Connection'
 import { SecretIdUseOption } from './crypto/SecretIdUseOption'
+import { AbstractFilterMessage } from '../icc-api/model/AbstractFilterMessage'
+import { BulkShareOrUpdateMetadataParams } from '../icc-api/model/requests/BulkShareOrUpdateMetadataParams'
 
 export class IccMessageXApi extends IccMessageApi implements EncryptedEntityXApi<models.Message> {
   private readonly encryptedFields: EncryptedFieldsManifest
@@ -236,25 +238,27 @@ export class IccMessageXApi extends IccMessageApi implements EncryptedEntityXApi
   ): Promise<ShareResult<models.Message>> {
     // All entities should have an encryption key.
     const entityWithEncryptionKey = await this.crypto.xapi.ensureEncryptionKeysInitialised(message, EntityWithDelegationTypeName.Message)
-    const updatedEntity = entityWithEncryptionKey ? await this.modifyMessage(entityWithEncryptionKey) : message
-    return this.crypto.xapi.simpleShareOrUpdateEncryptedEntityMetadata(
-      {
-        entity: updatedEntity,
-        type: EntityWithDelegationTypeName.Message,
-      },
-      Object.fromEntries(
-        Object.entries(delegates).map(([delegateId, options]) => [
-          delegateId,
-          {
-            requestedPermissions: options.requestedPermissions,
-            shareEncryptionKeys: options.shareEncryptionKey,
-            shareOwningEntityIds: options.sharePatientId,
-            shareSecretIds: options.shareSecretIds,
-          },
-        ])
-      ),
-      (x) => this.bulkShareMessages(x)
-    )
+    const updatedEntity = entityWithEncryptionKey ? await this.modifyMessageWithUser(undefined, entityWithEncryptionKey) : message
+    return this.crypto.xapi
+      .simpleShareOrUpdateEncryptedEntityMetadata(
+        {
+          entity: updatedEntity,
+          type: EntityWithDelegationTypeName.Message,
+        },
+        Object.fromEntries(
+          Object.entries(delegates).map(([delegateId, options]) => [
+            delegateId,
+            {
+              requestedPermissions: options.requestedPermissions,
+              shareEncryptionKeys: options.shareEncryptionKey,
+              shareOwningEntityIds: options.sharePatientId,
+              shareSecretIds: options.shareSecretIds,
+            },
+          ])
+        ),
+        (x) => super.bulkShareMessages(x)
+      )
+      .then((r) => r.mapSuccessAsync(async (m) => (await this.decrypt([m]))[0].entity))
   }
 
   /**
@@ -266,6 +270,10 @@ export class IccMessageXApi extends IccMessageApi implements EncryptedEntityXApi
     return this.crypto.xapi.secretIdsOf({ entity: message, type: EntityWithDelegationTypeName.Message }, undefined)
   }
 
+  createDelegationDeAnonymizationMetadata(entity: Message, delegates: string[]): Promise<void> {
+    return this.crypto.delegationsDeAnonymization.createOrUpdateDeAnonymizationInfo({ entity, type: EntityWithDelegationTypeName.Message }, delegates)
+  }
+
   getDataOwnersWithAccessTo(
     entity: models.Message
   ): Promise<{ permissionsByDataOwnerId: { [p: string]: AccessLevelEnum }; hasUnknownAnonymousDataOwners: boolean }> {
@@ -274,33 +282,6 @@ export class IccMessageXApi extends IccMessageApi implements EncryptedEntityXApi
 
   getEncryptionKeysOf(entity: models.Message): Promise<string[]> {
     return this.crypto.xapi.encryptionKeysOf({ entity, type: EntityWithDelegationTypeName.Message }, undefined)
-  }
-
-  override async filterMessagesBy(body: FilterChainMessage, startDocumentId?: string, limit?: number): Promise<PaginatedListMessage> {
-    const page = await super.filterMessagesBy(body, startDocumentId, limit)
-    const decryptedMessages = await this.decrypt(page.rows ?? [])
-    if (decryptedMessages.some((m) => !m.decrypted)) throw new Error('Some messages could not be decrypted')
-    return {
-      ...page,
-      rows: decryptedMessages.map((m) => m.entity),
-    }
-  }
-
-  async encryptAndCreateMessageInTopic(body: Message): Promise<Message> {
-    const encryptedMessage = await this.encrypt([body])
-    const createdMessage = await super.createMessageInTopic(encryptedMessage[0])
-    return (await this.decrypt([createdMessage]))[0].entity
-  }
-
-  async setMessagesReadStatus(body?: MessagesReadStatusUpdate): Promise<Array<Message>> {
-    return (await this.decrypt(await super.setMessagesReadStatus(body))).map((m) => m.entity)
-  }
-
-  async getAndDecryptMessage(messageId: string): Promise<Message> {
-    const encryptedMessage = await super.getMessage(messageId)
-    const decryptedMessage = await this.decrypt([encryptedMessage])
-    if (!decryptedMessage[0].decrypted) throw new Error('Message could not be decrypted')
-    return decryptedMessage[0].entity
   }
 
   async subscribeToMessageEvents(
@@ -321,7 +302,217 @@ export class IccMessageXApi extends IccMessageApi implements EncryptedEntityXApi
     ).then((rs) => new ConnectionImpl(rs))
   }
 
-  createDelegationDeAnonymizationMetadata(entity: Message, delegates: string[]): Promise<void> {
-    return this.crypto.delegationsDeAnonymization.createOrUpdateDeAnonymizationInfo({ entity, type: EntityWithDelegationTypeName.Message }, delegates)
+  private async decryptPage(page: PaginatedListMessage): Promise<PaginatedListMessage> {
+    return {
+      ...page,
+      rows: (await this.decrypt(page.rows ?? [])).map((x) => x.entity),
+    }
+  }
+
+  async createMessageWithUser(user: models.User | undefined, body: Message): Promise<Message> {
+    return (await this.decrypt([await super.createMessage((await this.encrypt([body]))[0])]))[0].entity
+  }
+
+  async findMessagesWithUser(
+    user: models.User | undefined,
+    startKey?: string,
+    startDocumentId?: string,
+    limit?: number
+  ): Promise<PaginatedListMessage> {
+    return await this.decryptPage(await super.findMessages(startKey, startDocumentId, limit))
+  }
+
+  async findMessagesByFromAddressWithUser(
+    user: models.User | undefined,
+    fromAddress?: string,
+    startKey?: string,
+    startDocumentId?: string,
+    limit?: number,
+    hcpId?: string
+  ): Promise<PaginatedListMessage> {
+    return await this.decryptPage(await super.findMessagesByFromAddress(fromAddress, startKey, startDocumentId, limit, hcpId))
+  }
+
+  /**
+   * @deprecated
+   */
+  async findMessagesByHCPartyPatientForeignKeysUsingPostWithUser(user: models.User | undefined, body?: Array<string>): Promise<Array<Message>> {
+    return (await this.decrypt(await super.findMessagesByHCPartyPatientForeignKeysUsingPost(body))).map((x) => x.entity)
+  }
+
+  /**
+   * @deprecated
+   */
+  async findMessagesByHCPartyPatientForeignKeysWithUser(user: models.User | undefined, secretFKeys: string): Promise<Array<Message>> {
+    return (await this.decrypt(await super.findMessagesByHCPartyPatientForeignKeys(secretFKeys))).map((x) => x.entity)
+  }
+
+  async findMessagesByToAddressWithUser(
+    user: models.User | undefined,
+    toAddress?: string,
+    startKey?: string,
+    startDocumentId?: string,
+    limit?: number,
+    reverse?: boolean,
+    hcpId?: string
+  ): Promise<PaginatedListMessage> {
+    return await this.decryptPage(await super.findMessagesByToAddress(toAddress, startKey, startDocumentId, limit, reverse, hcpId))
+  }
+
+  async findMessagesByTransportGuidWithUser(
+    user: models.User | undefined,
+    transportGuid?: string,
+    received?: boolean,
+    startKey?: string,
+    startDocumentId?: string,
+    limit?: number,
+    hcpId?: string
+  ): Promise<PaginatedListMessage> {
+    return await this.decryptPage(await super.findMessagesByTransportGuid(transportGuid, received, startKey, startDocumentId, limit, hcpId))
+  }
+
+  async findMessagesByTransportGuidSentDateWithUser(
+    user: models.User | undefined,
+    transportGuid?: string,
+    from?: number,
+    to?: number,
+    startKey?: string,
+    startDocumentId?: string,
+    limit?: number,
+    hcpId?: string
+  ): Promise<PaginatedListMessage> {
+    return await this.decryptPage(await super.findMessagesByTransportGuidSentDate(transportGuid, from, to, startKey, startDocumentId, limit, hcpId))
+  }
+
+  async getChildrenMessagesWithUser(user: models.User | undefined, messageId: string): Promise<Array<Message>> {
+    return (await this.decrypt(await super.getChildrenMessages(messageId))).map((x) => x.entity)
+  }
+
+  async getChildrenMessagesOfListWithUser(user: models.User | undefined, body?: ListOfIds): Promise<Array<Message>> {
+    return (await this.decrypt(await super.getChildrenMessagesOfList(body))).map((x) => x.entity)
+  }
+
+  async getMessageWithUser(user: models.User | undefined, messageId: string): Promise<Message> {
+    return (await this.decrypt([await super.getMessage(messageId)]))[0].entity
+  }
+
+  async getMessagesWithUser(user: models.User | undefined, messageIds: ListOfIds): Promise<Message[]> {
+    return (await this.decrypt(await super.getMessages(messageIds))).map((x) => x.entity)
+  }
+
+  async listMessagesByInvoiceIdsWithUser(user: models.User | undefined, body?: ListOfIds): Promise<Array<Message>> {
+    return (await this.decrypt(await super.listMessagesByInvoiceIds(body))).map((x) => x.entity)
+  }
+
+  async listMessagesByTransportGuidsWithUser(user: models.User | undefined, hcpId: string, body?: ListOfIds): Promise<Array<Message>> {
+    return (await this.decrypt(await super.listMessagesByTransportGuids(hcpId, body))).map((x) => x.entity)
+  }
+
+  async modifyMessageWithUser(user: models.User | undefined, body: Message): Promise<Message> {
+    return (await this.decrypt([await super.modifyMessage((await this.encrypt([body]))[0])]))[0].entity
+  }
+
+  async setMessagesStatusBitsWithUser(user: models.User | undefined, status: number, body?: ListOfIds): Promise<Array<Message>> {
+    return (await this.decrypt(await super.setMessagesStatusBits(status, body))).map((x) => x.entity)
+  }
+
+  async filterMessagesByWithUser(
+    user: models.User | undefined,
+    body: FilterChainMessage,
+    startDocumentId?: string,
+    limit?: number
+  ): Promise<PaginatedListMessage> {
+    return await this.decryptPage(await super.filterMessagesBy(body, startDocumentId, limit))
+  }
+
+  async setMessagesReadStatusWithUser(user: models.User | undefined, body?: MessagesReadStatusUpdate): Promise<Array<Message>> {
+    return (await this.decrypt(await super.setMessagesReadStatus(body))).map((x) => x.entity)
+  }
+
+  createMessage(body?: Message): never {
+    throw new Error('Use withUser method')
+  }
+
+  findMessages(startKey?: string, startDocumentId?: string, limit?: number): never {
+    throw new Error('Use withUser method')
+  }
+
+  findMessagesByFromAddress(fromAddress?: string, startKey?: string, startDocumentId?: string, limit?: number, hcpId?: string): never {
+    throw new Error('Use withUser method')
+  }
+
+  findMessagesByHCPartyPatientForeignKeysUsingPost(body?: Array<string>): never {
+    throw new Error('Use withUser method')
+  }
+
+  findMessagesByHCPartyPatientForeignKeys(secretFKeys: string): never {
+    throw new Error('Use withUser method')
+  }
+
+  findMessagesByToAddress(toAddress?: string, startKey?: string, startDocumentId?: string, limit?: number, reverse?: boolean, hcpId?: string): never {
+    throw new Error('Use withUser method')
+  }
+
+  findMessagesByTransportGuid(
+    transportGuid?: string,
+    received?: boolean,
+    startKey?: string,
+    startDocumentId?: string,
+    limit?: number,
+    hcpId?: string
+  ): never {
+    throw new Error('Use withUser method')
+  }
+
+  findMessagesByTransportGuidSentDate(
+    transportGuid?: string,
+    from?: number,
+    to?: number,
+    startKey?: string,
+    startDocumentId?: string,
+    limit?: number,
+    hcpId?: string
+  ): never {
+    throw new Error('Use withUser method')
+  }
+
+  getChildrenMessages(messageId: string): never {
+    throw new Error('Use withUser method')
+  }
+
+  getChildrenMessagesOfList(body?: ListOfIds): never {
+    throw new Error('Use withUser method')
+  }
+
+  getMessage(messageId: string): never {
+    throw new Error('Use withUser method')
+  }
+
+  getMessages(messageIds: ListOfIds): never {
+    throw new Error('Use withUser method')
+  }
+
+  listMessagesByInvoiceIds(body?: ListOfIds): never {
+    throw new Error('Use withUser method')
+  }
+
+  listMessagesByTransportGuids(hcpId: string, body?: ListOfIds): never {
+    throw new Error('Use withUser method')
+  }
+
+  modifyMessage(body?: Message): never {
+    throw new Error('Use withUser method')
+  }
+
+  setMessagesStatusBits(status: number, body?: ListOfIds): never {
+    throw new Error('Use withUser method')
+  }
+
+  filterMessagesBy(body: FilterChainMessage, startDocumentId?: string, limit?: number): never {
+    throw new Error('Use withUser method')
+  }
+
+  setMessagesReadStatus(body?: MessagesReadStatusUpdate): never {
+    throw new Error('Use withUser method')
   }
 }

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -973,19 +973,21 @@ export class IccPatientXApi extends IccPatientApi implements EncryptedEntityXApi
                     c.services.forEach((s) => s.content && Object.values(s.content).forEach((c) => c && c.documentId && (docIds[c.documentId] = 1)))
                 )
 
-                return retry(() => this.documentApi.getDocuments(new ListOfIds({ ids: Object.keys(docIds) }))).then((docs: Array<Document>) => {
-                  return {
-                    id: patId,
-                    patient: patient,
-                    contacts: ctcs,
-                    forms: frms,
-                    healthElements: hes,
-                    invoices: ivs,
-                    classifications: cls,
-                    calItems: cis,
-                    documents: docs,
+                return retry(() => this.documentApi.getDocumentsWithUser(undefined, new ListOfIds({ ids: Object.keys(docIds) }))).then(
+                  (docs: Array<Document>) => {
+                    return {
+                      id: patId,
+                      patient: patient,
+                      contacts: ctcs,
+                      forms: frms,
+                      healthElements: hes,
+                      invoices: ivs,
+                      classifications: cls,
+                      calItems: cis,
+                      documents: docs,
+                    }
                   }
-                })
+                )
               })
             : Promise.resolve({
                 id: patId,

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -863,145 +863,118 @@ export class IccPatientXApi extends IccPatientApi implements EncryptedEntityXApi
       })
   }
 
-  export(user: models.User, patId: string, ownerId: string, usingPost: boolean = false): Promise<{ id: string }> {
-    return this.hcpartyApi.getHealthcareParty(ownerId).then((hcp) => {
-      const parentId = hcp.parentId
-
-      return retry(() => this.getPatientWithUser(user, patId))
-        .then(async (patient: models.Patient) => {
-          const initialised = await this.crypto.xapi.ensureEncryptionKeysInitialised(patient, EntityWithDelegationTypeName.Patient)
-          if (!initialised) {
-            return patient
-          } else {
-            return await this.modifyPatientWithUser(user, initialised)
-          }
-        })
-        .then(async (patient: models.Patient | null) => {
-          if (!patient) {
-            return Promise.resolve({ id: patId })
-          }
-          const delSfks = await this.crypto.xapi.secretIdsOf({ entity: patient, type: EntityWithDelegationTypeName.Patient }, ownerId)
-          return delSfks.length
-            ? Promise.all([
-                retry(() =>
-                  (usingPost
-                    ? this.helementApi.findByHCPartyPatientSecretFKeys(ownerId, _.uniq(delSfks).join(','))
-                    : this.helementApi.findByHCPartyPatientSecretFKeysArray(ownerId, delSfks)
-                  ).then((hes) =>
-                    parentId
-                      ? (usingPost
-                          ? this.helementApi.findHealthElementsDelegationsStubsByHCPartyPatientForeignKeysUsingPost(parentId, _.uniq(delSfks))
-                          : this.helementApi.findHealthElementsDelegationsStubsByHCPartyPatientForeignKeys(parentId, _.uniq(delSfks).join(','))
-                        ).then((moreHes) => _.uniqBy(hes.concat(moreHes), 'id'))
-                      : hes
-                  )
-                ) as Promise<Array<models.IcureStub>>,
-                retry(() =>
-                  (usingPost
-                    ? this.formApi.findFormsDelegationsStubsByHCPartyPatientForeignKeysUsingPost(ownerId, _.uniq(delSfks))
-                    : this.formApi.findFormsDelegationsStubsByHCPartyPatientForeignKeys(ownerId, _.uniq(delSfks).join(','))
-                  ).then((frms) =>
-                    parentId
-                      ? (usingPost
-                          ? this.formApi.findFormsDelegationsStubsByHCPartyPatientForeignKeysUsingPost(parentId, _.uniq(delSfks))
-                          : this.formApi.findFormsDelegationsStubsByHCPartyPatientForeignKeys(parentId, _.uniq(delSfks).join(','))
-                        ).then((moreFrms) => _.uniqBy(frms.concat(moreFrms), 'id'))
-                      : frms
-                  )
-                ) as Promise<Array<models.Form>>,
-                retry(() =>
-                  (usingPost
-                    ? this.contactApi.findByHCPartyPatientSecretFKeysUsingPost(ownerId, undefined, undefined, _.uniq(delSfks))
-                    : this.contactApi.findByHCPartyPatientSecretFKeys(ownerId, _.uniq(delSfks).join(','))
-                  ).then((ctcs) =>
-                    parentId
-                      ? (usingPost
-                          ? this.contactApi.findByHCPartyPatientSecretFKeysUsingPost(parentId, undefined, undefined, _.uniq(delSfks))
-                          : this.contactApi.findByHCPartyPatientSecretFKeys(parentId, _.uniq(delSfks).join(','))
-                        ).then((moreCtcs) => _.uniqBy(ctcs.concat(moreCtcs), 'id'))
-                      : ctcs
-                  )
-                ) as Promise<Array<models.Contact>>,
-                retry(() =>
-                  (usingPost
-                    ? this.invoiceApi.findInvoicesDelegationsStubsByHCPartyPatientForeignKeysUsingPost(ownerId, _.uniq(delSfks))
-                    : this.invoiceApi.findInvoicesDelegationsStubsByHCPartyPatientForeignKeys(ownerId, _.uniq(delSfks).join(','))
-                  ).then((ivs) =>
-                    parentId
-                      ? this.invoiceApi
-                          .findInvoicesDelegationsStubsByHCPartyPatientForeignKeys(parentId, _.uniq(delSfks).join(','))
-                          .then((moreIvs) => _.uniqBy(ivs.concat(moreIvs), 'id'))
-                      : ivs
-                  )
-                ) as Promise<Array<models.IcureStub>>,
-                retry(() =>
-                  this.classificationApi
-                    .findClassificationsByHCPartyPatientForeignKeys(ownerId, _.uniq(delSfks).join(','))
-                    .then((cls) =>
-                      parentId
-                        ? this.classificationApi
-                            .findClassificationsByHCPartyPatientForeignKeys(parentId, _.uniq(delSfks).join(','))
-                            .then((moreCls) => _.uniqBy(cls.concat(moreCls), 'id'))
-                        : cls
-                    )
-                ) as Promise<Array<models.Classification>>,
-                retry(async () => {
-                  const delegationSFKs = _.uniq(delSfks).join(',')
-                  try {
-                    let calendarItems = await (usingPost
-                      ? this.calendarItemApi.findByHCPartyPatientSecretFKeysArray(ownerId, _.uniq(delSfks))
-                      : this.calendarItemApi.findByHCPartyPatientSecretFKeys(ownerId, _.uniq(delSfks).join(',')))
-
-                    if (parentId) {
-                      const moreCalendarItems = await (usingPost
-                        ? this.calendarItemApi.findByHCPartyPatientSecretFKeysArray(parentId, _.uniq(delSfks))
-                        : this.calendarItemApi.findByHCPartyPatientSecretFKeys(parentId, _.uniq(delSfks).join(',')))
-                      calendarItems = _.uniqBy(calendarItems.concat(moreCalendarItems), 'id')
-                    }
-
-                    return calendarItems
-                  } catch (ex) {
-                    console.log(`exception occured exporting calendarItem for ownerId: ${ownerId} - ${ex}`)
-                    //throw ex
-                  }
-                }) as Promise<Array<models.CalendarItem>>,
-              ]).then(([hes, frms, ctcs, ivs, cls, cis]) => {
-                const docIds: { [key: string]: number } = {}
-                ctcs.forEach(
-                  (c: models.Contact) =>
-                    c.services &&
-                    c.services.forEach((s) => s.content && Object.values(s.content).forEach((c) => c && c.documentId && (docIds[c.documentId] = 1)))
-                )
-
-                return retry(() => this.documentApi.getDocumentsWithUser(undefined, new ListOfIds({ ids: Object.keys(docIds) }))).then(
-                  (docs: Array<Document>) => {
-                    return {
-                      id: patId,
-                      patient: patient,
-                      contacts: ctcs,
-                      forms: frms,
-                      healthElements: hes,
-                      invoices: ivs,
-                      classifications: cls,
-                      calItems: cis,
-                      documents: docs,
-                    }
-                  }
-                )
-              })
-            : Promise.resolve({
-                id: patId,
-                patient: patient,
-                contacts: [],
-                forms: [],
-                healthElements: [],
-                invoices: [],
-                classifications: [],
-                calItems: [],
-                documents: [],
-              })
-        })
+  async export(
+    user: models.User,
+    patId: string,
+    ownerId: string
+  ): Promise<{
+    id: string
+    patient: Patient | null
+    contacts: models.Contact[]
+    forms: models.Form[]
+    healthElements: models.HealthElement[]
+    invoices: models.Invoice[]
+    classifications: models.Classification[]
+    calItems: models.CalendarItem[]
+    documents: models.Document[]
+  }> {
+    const parentId = await this.dataOwnerApi.getCurrentDataOwnerHierarchyIds().then((h) => (h.length - 2 >= 0 ? h[h.length - 2] : h[0]))
+    const patient = await retry(async () => {
+      const retrieved: Patient | undefined = await this.getPatientWithUser(user, patId)
+      if (retrieved != undefined) {
+        const initialised = await this.crypto.xapi.ensureEncryptionKeysInitialised(retrieved, EntityWithDelegationTypeName.Patient)
+        if (!initialised) {
+          return retrieved
+        } else {
+          return await this.modifyPatientWithUser(user, initialised)
+        }
+      } else {
+        return null
+      }
     })
+    const delSfks =
+      patient != null ? await this.crypto.xapi.secretIdsOf({ entity: patient, type: EntityWithDelegationTypeName.Patient }, ownerId) : []
+    if (delSfks.length <= 0) {
+      return {
+        id: patId,
+        patient,
+        contacts: [],
+        forms: [],
+        healthElements: [],
+        invoices: [],
+        classifications: [],
+        calItems: [],
+        documents: [],
+      }
+    }
+    const contactIds = new Set([
+      ...(await retry(() => this.contactApi.findContactIdsByDataOwnerPatientOpeningDate(ownerId, delSfks))),
+      ...(await retry(() => this.contactApi.findContactIdsByDataOwnerPatientOpeningDate(parentId, delSfks))),
+    ])
+    const formIds = new Set([
+      ...(await retry(() => this.formApi.findFormIdsByDataOwnerPatientOpeningDate(ownerId, delSfks))),
+      ...(await retry(() => this.formApi.findFormIdsByDataOwnerPatientOpeningDate(parentId, delSfks))),
+    ])
+    const healthElementIds = new Set([
+      ...(await retry(() => this.helementApi.findHealthElementIdsByDataOwnerPatientOpeningDate(ownerId, delSfks))),
+      ...(await retry(() => this.helementApi.findHealthElementIdsByDataOwnerPatientOpeningDate(parentId, delSfks))),
+    ])
+    const invoiceIds = new Set([
+      ...(await retry(() => this.invoiceApi.findInvoiceIdsByDataOwnerPatientInvoiceDate(ownerId, delSfks))),
+      ...(await retry(() => this.invoiceApi.findInvoiceIdsByDataOwnerPatientInvoiceDate(parentId, delSfks))),
+    ])
+    const classificationIds = new Set([
+      ...(await retry(() => this.classificationApi.findClassificationIdsByDataOwnerPatientCreated(ownerId, delSfks))),
+      ...(await retry(() => this.classificationApi.findClassificationIdsByDataOwnerPatientCreated(parentId, delSfks))),
+    ])
+    const calendarItemIds = new Set([
+      ...(await retry(() => this.calendarItemApi.findCalendarItemIdsByDataOwnerPatientStartTime(ownerId, delSfks))),
+      ...(await retry(() => this.calendarItemApi.findCalendarItemIdsByDataOwnerPatientStartTime(parentId, delSfks))),
+    ])
+    async function batchGet<T>(items: string[], get: (batch: string[]) => Promise<T[]>, batchSize: number = 1000): Promise<T[]> {
+      const results: T[] = []
+      for (let i = 0; i < items.length; i += batchSize) {
+        const batch = items.slice(i, i + batchSize)
+        const res = await retry(() => get(batch))
+        results.push(...res)
+      }
+      return results
+    }
+    const contacts = await batchGet([...contactIds], (x): Promise<models.Contact[]> => this.contactApi.getContactsWithUser(user, { ids: x }))
+    const forms = await batchGet([...formIds], (x): Promise<models.Form[]> => this.formApi.getForms({ ids: x }))
+    const healthElements = await batchGet(
+      [...healthElementIds],
+      (x): Promise<models.HealthElement[]> => this.helementApi.getHealthElementsWithUser(user, { ids: x })
+    )
+    const invoices = await batchGet([...invoiceIds], (x): Promise<models.Invoice[]> => this.invoiceApi.getInvoices({ ids: x }))
+    const classifications = await batchGet(
+      [...classificationIds],
+      (x): Promise<models.Classification[]> => this.classificationApi.getClassifications({ ids: x })
+    )
+    const calItems = await batchGet(
+      [...calendarItemIds],
+      (x): Promise<models.CalendarItem[]> => this.calendarItemApi.getCalendarItemsWithIdsWithUser(user, { ids: x })
+    )
+    const documentIds = new Set<string>()
+    contacts.forEach((contact) => {
+      contact.services?.forEach((service) => {
+        Object.values(service.content ?? {}).forEach((content) => {
+          if (!!content.documentId) documentIds.add(content.documentId)
+        })
+      })
+    })
+    const documents = await batchGet([...documentIds], (x): Promise<models.Document[]> => this.documentApi.getDocumentsWithUser(user, { ids: x }))
+    return {
+      id: patId,
+      patient,
+      calItems,
+      classifications,
+      contacts,
+      documents,
+      forms,
+      healthElements,
+      invoices,
+    }
   }
 
   checkInami(inami: string): boolean {

--- a/icc-x-api/index.ts
+++ b/icc-x-api/index.ts
@@ -23,7 +23,8 @@ import {
   IccPlaceApi,
   IccPubsubApi,
   IccReplicationApi,
-  IccTarificationApi, IccTimeTableApi,
+  IccTarificationApi,
+  IccTimeTableApi,
   IccTmpApi,
   IccUserApi,
   OAuthThirdParty,
@@ -452,6 +453,12 @@ export interface EncryptedFieldsConfig {
    * @default ['description']
    */
   readonly topic?: string[]
+
+  /**
+   * Fields to encrypt for entities of type {@link Document}
+   * @default []
+   */
+  readonly document?: string[]
 }
 
 export namespace EncryptedFieldsConfig {
@@ -464,6 +471,7 @@ export namespace EncryptedFieldsConfig {
     maintenanceTask: ['properties'],
     patient: ['note', 'notes[].markdown'],
     message: [],
+    document: [],
     topic: ['description', 'linkedServices', 'linkedHealthElements'],
   }
 }
@@ -1101,6 +1109,7 @@ class IcureApiImpl implements IcureApi {
         this.dataOwnerApi,
         !this.cryptoInitInfos.dataOwnerRequiresAnonymousDelegation,
         this.groupSpecificAuthenticationProvider,
+        this.params.encryptedFieldsConfig.document ?? EncryptedFieldsConfig.Defaults.document,
         this.fetch
       ))
     )
@@ -1183,12 +1192,7 @@ class IcureApiImpl implements IcureApi {
   get timetableApi(): IccTimeTableApi {
     return (
       this._timetableApi ??
-      (this._timetableApi = new IccTimeTableApi(
-        this.host,
-        this.cryptoInitInfos.headers,
-        this.groupSpecificAuthenticationProvider,
-        this.fetch
-      ))
+      (this._timetableApi = new IccTimeTableApi(this.host, this.cryptoInitInfos.headers, this.groupSpecificAuthenticationProvider, this.fetch))
     )
   }
 

--- a/test/icc-x-api/icc-document-x-api.ts
+++ b/test/icc-x-api/icc-document-x-api.ts
@@ -1,4 +1,4 @@
-import { before } from 'mocha'
+import { before, it } from 'mocha'
 
 import 'isomorphic-fetch'
 
@@ -6,7 +6,7 @@ import { EntityWithDelegationTypeName, IccContactXApi, IccHelementXApi, IccPatie
 import { Patient } from '../../icc-api/model/Patient'
 import { assert, expect } from 'chai'
 import { randomUUID } from 'crypto'
-import { getEnvironmentInitializer, hcp1Username, hcp2Username, setLocalStorage, TestUtils } from '../utils/test_utils'
+import { createNewHcpApi, getEnvironmentInitializer, hcp1Username, hcp2Username, setLocalStorage, TestUtils } from '../utils/test_utils'
 import { Code } from '../../icc-api/model/Code'
 import { Contact } from '../../icc-api/model/Contact'
 import { Service } from '../../icc-api/model/Service'
@@ -20,6 +20,7 @@ import { ServiceByHcPartyHealthElementIdsFilter } from '../../icc-x-api/filters/
 import { getEnvVariables, TestVars } from '@icure/test-setup/types'
 import { Measure } from '../../icc-api/model/Measure'
 import initApi = TestUtils.initApi
+import { IccDocumentApi, IccMessageApi } from '../../icc-api'
 
 setLocalStorage(fetch)
 let env: TestVars
@@ -36,7 +37,7 @@ describe('icc-x-document-api Tests', () => {
     const { documentApi, userApi } = await initApi(env!, hcp1Username)
 
     const currUser = await userApi.getCurrentUser()
-    const document = await documentApi.createDocument(await documentApi.newInstance(currUser, undefined, {}))
+    const document = await documentApi.createDocumentWithUser(undefined, await documentApi.newInstance(currUser, undefined, {}))
     const obj = { test: 'test' }
     await documentApi.encryptAndSetDocumentAttachment(document, utf8_2ua(JSON.stringify(obj)))
     const decrypted = await documentApi.getAndTryDecryptMainAttachmentAs(document, 'application/json')
@@ -48,12 +49,38 @@ describe('icc-x-document-api Tests', () => {
     const { documentApi, userApi } = await initApi(env!, hcp1Username)
 
     const currUser = await userApi.getCurrentUser()
-    const document = await documentApi.createDocument(await documentApi.newInstance(currUser, undefined, {}))
+    const document = await documentApi.createDocumentWithUser(undefined, await documentApi.newInstance(currUser, undefined, {}))
     const obj = 'Test'
     await documentApi.encryptAndSetDocumentAttachment(document, utf8_2ua(obj))
     const decrypted = await documentApi.getAndTryDecryptMainAttachmentAs(document, 'text/plain')
     expect(decrypted).to.deep.equal(obj)
     const decryptedAsJson = await documentApi.getAndTryDecryptMainAttachmentAs(document, 'application/json')
     expect(decryptedAsJson).to.be.undefined
+  })
+
+  it('Should be encrypted', async () => {
+    const hcp = await createNewHcpApi(env, {
+      encryptedFieldsConfig: {
+        document: ['name'],
+      },
+    })
+    const name = 'Private.txt'
+    const externalUuid = randomUUID()
+    const created = await hcp.api.documentApi.createDocumentWithUser(
+      undefined,
+      await hcp.api.documentApi.newInstance(hcp.user, undefined, {
+        id: randomUUID(),
+        name,
+        externalUuid,
+      })
+    )
+    expect(created.name).to.eq(name)
+    expect(created.externalUuid).to.eq(externalUuid)
+    const retrieved = await hcp.api.documentApi.getDocumentWithUser(undefined, created.id!)
+    expect(retrieved.name).to.eq(name)
+    expect(retrieved.externalUuid).to.eq(externalUuid)
+    const encrypted = await new IccDocumentApi(env.iCureUrl, {}, hcp.api.authApi.authenticationProvider, fetch).getDocument(created.id!)
+    expect(encrypted.name).to.be.undefined
+    expect(encrypted.externalUuid).to.eq(externalUuid)
   })
 })

--- a/test/icc-x-api/icc-message-x-api.ts
+++ b/test/icc-x-api/icc-message-x-api.ts
@@ -1,5 +1,14 @@
 import 'isomorphic-fetch'
-import { describeNoLite, getEnvironmentInitializer, hcp1Username, hcp2Username, hcp3Username, setLocalStorage, TestUtils } from '../utils/test_utils'
+import {
+  createNewHcpApi,
+  describeNoLite,
+  getEnvironmentInitializer,
+  hcp1Username,
+  hcp2Username,
+  hcp3Username,
+  setLocalStorage,
+  TestUtils,
+} from '../utils/test_utils'
 import { before, it, describe } from 'mocha'
 import { IccMessageXApi, IccPatientXApi, sleep, SubscriptionOptions } from '../../icc-x-api'
 import { Patient } from '../../icc-api/model/Patient'
@@ -21,503 +30,43 @@ import { Connection } from '../../icc-api/model/Connection'
 import { expect, use as chaiUse } from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
 import { IccMessageApi } from '../../icc-api'
+import undefinedError = Mocha.utils.undefinedError
+import { create } from 'lodash'
 
 chaiUse(chaiAsPromised)
 setLocalStorage(fetch)
 let env: TestVars
 
-describeNoLite('icc-message-x-api Topic-based tests', () => {
+describe('icc-message-x-api', () => {
   before(async function () {
     this.timeout(600000)
     const initializer = await getEnvironmentInitializer()
     env = await initializer.execute(getEnvVariables())
   })
 
-  async function createMessage(messageApi: IccMessageXApi, hcpUser: User, patient: Patient | null, topic: Topic) {
-    return messageApi.encryptAndCreateMessageInTopic(
-      await messageApi.newInstanceWithPatient(
-        hcpUser,
-        patient,
-        new Message({
-          id: randomUUID(),
-          subject: 'Message Subject',
-          sent: new Date().getTime(),
-          transportGuid: topic.id,
-          readStatus: Object.fromEntries(
-            Object.keys(topic.activeParticipants ?? {})
-              .filter((p) => p != hcpUser.healthcarePartyId)
-              .map((hcpId) => [hcpId, { read: false }])
-          ),
-          fromHealthcarePartyId: hcpUser.healthcarePartyId,
-        }),
-        {
-          additionalDelegates: Object.fromEntries(
-            Object.keys(topic.activeParticipants ?? {})
-              .filter((hcpId) => hcpId != hcpUser.healthcarePartyId)
-              .map((hcpId) => [hcpId, SecureDelegation.AccessLevelEnum.READ])
-          ),
-        }
-      )
-    )
-  }
-
-  async function createTopic(topicApi: IccTopicXApi, hcpUser: User, patient: Patient, ...additionalUser: { user: User; role: TopicRole }[]) {
-    return topicApi.createTopic(
-      await topicApi.newInstance(
-        hcpUser,
-        patient,
-        new Topic({
-          id: randomUUID(),
-          description: 'Topic description',
-          activeParticipants: {
-            ...Object.fromEntries(additionalUser.map((u) => [u.user.healthcarePartyId!, u.role])),
-            [hcpUser.healthcarePartyId!]: TopicRole.OWNER,
-          },
-        }),
-        {
-          additionalDelegates: Object.fromEntries(additionalUser.map((u) => [u.user.healthcarePartyId!, SecureDelegation.AccessLevelEnum.WRITE])),
-        }
-      )
-    )
-  }
-
-  async function createPatient(patientApiForHcp: IccPatientXApi, hcpUser: User) {
-    return patientApiForHcp.createPatientWithUser(
-      hcpUser,
-      await patientApiForHcp.newInstance(
-        hcpUser,
-        new Patient({
-          id: randomUUID(),
-          firstName: 'John',
-          lastName: 'Snow',
-          note: 'Winter is coming',
-        })
-      )
-    )
-  }
-
-  it('An HCP should be able to publish a message on a topic and a participant can read it', async () => {
-    const {
-      userApi: userApiForHcp,
-      topicApi: topicApiForHcp,
-      patientApi: patientApiForHcp,
-      messageApi: messageApiForHcp,
-    } = await initApi(env!, hcp1Username)
-
-    const { userApi: userApiForHcp2, messageApi: messageApiForHcp2 } = await initApi(env!, hcp2Username)
-
-    const hcpUser = await userApiForHcp.getCurrentUser()
-    const hcpUser2 = await userApiForHcp2.getCurrentUser()
-
-    const samplePatient = await createPatient(patientApiForHcp, hcpUser)
-    const createdTopic = await createTopic(topicApiForHcp, hcpUser, samplePatient, { user: hcpUser2, role: TopicRole.PARTICIPANT })
-
-    const createdMessage = await createMessage(messageApiForHcp, hcpUser, null, createdTopic)
-
-    const message = await messageApiForHcp.getAndDecryptMessage(createdMessage.id!)
-    const message2 = await messageApiForHcp2.getAndDecryptMessage(createdMessage.id!)
-
-    expect(message).to.deep.equal(createdMessage)
-    expect(message).to.deep.equal(message2)
-  })
-
-  it('An HCP should be able to publish an encrypted message on a topic', async () => {
-    const {
-      userApi: userApiForHcp,
-      topicApi: topicApiForHcp,
-      patientApi: patientApiForHcp,
-      messageApi: messageApiForHcp,
-    } = await initApi(env!, hcp1Username, {
+  it('Should be encrypted', async () => {
+    const hcp = await createNewHcpApi(env, {
       encryptedFieldsConfig: {
         message: ['subject'],
       },
     })
-
-    const baseMessageApi = new IccMessageApi(
-      env!.iCureUrl,
-      messageApiForHcp._headers,
-      messageApiForHcp.authenticationProvider,
-      messageApiForHcp.fetchImpl
+    const subject = 'Hello'
+    const transportGuid = randomUUID()
+    const created = await hcp.api.messageApi.createMessageWithUser(
+      undefined,
+      await hcp.api.messageApi.newInstance(hcp.user, {
+        id: randomUUID(),
+        subject,
+        transportGuid,
+      })
     )
-
-    const hcpUser = await userApiForHcp.getCurrentUser()
-
-    const samplePatient = await createPatient(patientApiForHcp, hcpUser)
-    const createdTopic = await createTopic(topicApiForHcp, hcpUser, samplePatient)
-
-    const createdMessage = await createMessage(messageApiForHcp, hcpUser, null, createdTopic)
-
-    const message = await messageApiForHcp.getAndDecryptMessage(createdMessage.id!)
-    expect(message).to.deep.equal(createdMessage)
-    expect(message.subject).to.not.be.undefined
-
-    const notDecryptedMessage = await baseMessageApi.getMessage(createdMessage.id!)
-    expect(notDecryptedMessage).to.not.deep.equal(createdMessage)
-    expect(notDecryptedMessage.subject).to.be.undefined
+    expect(created.subject).to.eq(subject)
+    expect(created.transportGuid).to.eq(transportGuid)
+    const retrieved = await hcp.api.messageApi.getMessageWithUser(undefined, created.id!)
+    expect(retrieved.subject).to.eq(subject)
+    expect(retrieved.transportGuid).to.eq(transportGuid)
+    const encrypted = await new IccMessageApi(env.iCureUrl, {}, hcp.api.authApi.authenticationProvider, fetch).getMessage(created.id!)
+    expect(encrypted.subject).to.be.undefined
+    expect(encrypted.transportGuid).to.eq(transportGuid)
   })
-
-  it('An HCP should be able to publish a message on a topic and a non-participant cannot read it', async () => {
-    const {
-      userApi: userApiForHcp,
-      topicApi: topicApiForHcp,
-      patientApi: patientApiForHcp,
-      messageApi: messageApiForHcp,
-    } = await initApi(env!, hcp1Username)
-
-    const { userApi: userApiForHcp2 } = await initApi(env!, hcp2Username)
-
-    const { messageApi: messageApiForHcp3 } = await initApi(env!, hcp3Username)
-
-    const hcpUser = await userApiForHcp.getCurrentUser()
-    const hcpUser2 = await userApiForHcp2.getCurrentUser()
-
-    const samplePatient = await createPatient(patientApiForHcp, hcpUser)
-    const createdTopic = await createTopic(topicApiForHcp, hcpUser, samplePatient, { user: hcpUser2, role: TopicRole.PARTICIPANT })
-
-    const createdMessage = await createMessage(messageApiForHcp, hcpUser, null, createdTopic)
-
-    const message = await messageApiForHcp.getAndDecryptMessage(createdMessage.id!)
-    expect(message).to.not.be.null
-
-    await messageApiForHcp3.getAndDecryptMessage(createdMessage.id!).then(
-      () => expect.fail('Should not be able to read the message'),
-      (e) => {
-        expect(e).to.be.instanceOf(XHR.XHRError)
-        expect((e as XHRError).statusCode).to.equal(403)
-      }
-    )
-  })
-
-  it('An HCP should be able to publish a message on a topic and a participant could query it through MessageByHcPartyFilter', async () => {
-    const {
-      userApi: userApiForHcp,
-      topicApi: topicApiForHcp,
-      patientApi: patientApiForHcp,
-      messageApi: messageApiForHcp,
-    } = await initApi(env!, hcp1Username)
-
-    const { userApi: userApiForHcp2, messageApi: messageApiForHcp2 } = await initApi(env!, hcp2Username)
-
-    const hcpUser = await userApiForHcp.getCurrentUser()
-    const hcpUser2 = await userApiForHcp2.getCurrentUser()
-
-    const samplePatient = await createPatient(patientApiForHcp, hcpUser)
-    const createdTopic = await createTopic(topicApiForHcp, hcpUser, samplePatient, { user: hcpUser2, role: TopicRole.PARTICIPANT })
-
-    const createdMessage = await createMessage(messageApiForHcp, hcpUser, null, createdTopic)
-
-    const message = await messageApiForHcp.getAndDecryptMessage(createdMessage.id!)
-
-    const filterChain = (hcpId: string) =>
-      new FilterChainMessage({
-        filter: new MessageByHcPartyFilter({
-          hcpId: hcpId,
-        }),
-      })
-
-    const filterResultForHcp = await messageApiForHcp.filterMessagesBy(filterChain(hcpUser.healthcarePartyId!))
-    expect(filterResultForHcp.rows).to.have.length.greaterThanOrEqual(1)
-    expect(filterResultForHcp.rows!.find((m) => m.id === message.id)).to.deep.equal(message)
-
-    const filterResultForHcp2 = await messageApiForHcp2.filterMessagesBy(filterChain(hcpUser2.healthcarePartyId!))
-    expect(filterResultForHcp2.rows).to.have.length.greaterThanOrEqual(1)
-    expect(filterResultForHcp2.rows!.find((m) => m.id === message.id)).to.deep.equal(message)
-  }).timeout(60_000)
-
-  it('An HCP should be able to publish a message on a topic and a non-participant should not be able to query it through MessageByHcPartyFilter', async () => {
-    const {
-      userApi: userApiForHcp,
-      topicApi: topicApiForHcp,
-      patientApi: patientApiForHcp,
-      messageApi: messageApiForHcp,
-    } = await initApi(env!, hcp1Username)
-
-    const { userApi: userApiForHcp2, messageApi: messageApiForHcp2 } = await initApi(env!, hcp2Username)
-
-    const { messageApi: messageApiForHcp3, userApi: userApiForHcp3 } = await initApi(env!, hcp3Username)
-
-    const hcpUser = await userApiForHcp.getCurrentUser()
-    const hcpUser2 = await userApiForHcp2.getCurrentUser()
-    const hcpUser3 = await userApiForHcp3.getCurrentUser()
-
-    const samplePatient = await createPatient(patientApiForHcp, hcpUser)
-
-    const createdTopic = await createTopic(topicApiForHcp, hcpUser, samplePatient, { user: hcpUser2, role: TopicRole.PARTICIPANT })
-
-    const createdMessage = await createMessage(messageApiForHcp, hcpUser, null, createdTopic)
-
-    const message = await messageApiForHcp.getAndDecryptMessage(createdMessage.id!)
-
-    const filterChain = (hcpId: string) =>
-      new FilterChainMessage({
-        filter: new MessageByHcPartyFilter({
-          hcpId: hcpId,
-        }),
-      })
-
-    const filterResultForHcp = await messageApiForHcp.filterMessagesBy(filterChain(hcpUser.healthcarePartyId!))
-    expect(filterResultForHcp.rows).to.have.length.greaterThanOrEqual(1)
-    expect(filterResultForHcp.rows!.find((m) => m.id === message.id)).to.deep.equal(message)
-
-    const filterResultForHcp2 = await messageApiForHcp2.filterMessagesBy(filterChain(hcpUser2.healthcarePartyId!))
-    expect(filterResultForHcp2.rows).to.have.length.greaterThanOrEqual(1)
-    expect(filterResultForHcp2.rows!.find((m) => m.id === message.id)).to.deep.equal(message)
-
-    const filterResultForHcp3 = await messageApiForHcp3.filterMessagesBy(filterChain(hcpUser3.healthcarePartyId!))
-    expect(filterResultForHcp3.rows!.find((m) => m.id === message.id)).to.be.undefined
-  })
-
-  it('An HCP should be able to publish a message on a topic and a participant could query it through MessageByHcPartyTransportGuidFilter', async () => {
-    const {
-      userApi: userApiForHcp,
-      topicApi: topicApiForHcp,
-      patientApi: patientApiForHcp,
-      messageApi: messageApiForHcp,
-    } = await initApi(env!, hcp1Username)
-
-    const { userApi: userApiForHcp2, messageApi: messageApiForHcp2 } = await initApi(env!, hcp2Username)
-
-    const hcpUser = await userApiForHcp.getCurrentUser()
-    const hcpUser2 = await userApiForHcp2.getCurrentUser()
-
-    const samplePatient = await createPatient(patientApiForHcp, hcpUser)
-    const createdTopic = await createTopic(topicApiForHcp, hcpUser, samplePatient, { user: hcpUser2, role: TopicRole.PARTICIPANT })
-
-    const createdMessage = await createMessage(messageApiForHcp, hcpUser, null, createdTopic)
-
-    const message = await messageApiForHcp.getAndDecryptMessage(createdMessage.id!)
-
-    const filterChain = (hcpId: string, transportGuid: string) =>
-      new FilterChainMessage({
-        filter: new MessageByHcPartyTransportGuidFilter({
-          healthcarePartyId: hcpId,
-          transportGuid: transportGuid,
-        }),
-      })
-
-    const filterResultForHcp = await messageApiForHcp.filterMessagesBy(filterChain(hcpUser.healthcarePartyId!, message.transportGuid!))
-    expect(filterResultForHcp.rows).to.have.length(1)
-    expect(filterResultForHcp.rows!.find((m) => m.id === message.id)).to.deep.equal(message)
-
-    const filterResultForHcp2 = await messageApiForHcp2.filterMessagesBy(filterChain(hcpUser2.healthcarePartyId!, message.transportGuid!))
-    expect(filterResultForHcp2.rows).to.have.length(1)
-    expect(filterResultForHcp2.rows!.find((m) => m.id === message.id)).to.deep.equal(message)
-  })
-
-  it('An HCP should be able to publish a message on a topic and a non-participant should not be able to query it through MessageByHcPartyTransportGuidFilter', async () => {
-    const {
-      userApi: userApiForHcp,
-      topicApi: topicApiForHcp,
-      patientApi: patientApiForHcp,
-      messageApi: messageApiForHcp,
-    } = await initApi(env!, hcp1Username)
-
-    const { userApi: userApiForHcp2, messageApi: messageApiForHcp2 } = await initApi(env!, hcp2Username)
-
-    const { userApi: userApiForHcp3, messageApi: messageApiForHcp3 } = await initApi(env!, hcp3Username)
-
-    const hcpUser = await userApiForHcp.getCurrentUser()
-    const hcpUser2 = await userApiForHcp2.getCurrentUser()
-    const hcpUser3 = await userApiForHcp3.getCurrentUser()
-
-    const samplePatient = await createPatient(patientApiForHcp, hcpUser)
-    const createdTopic = await createTopic(topicApiForHcp, hcpUser, samplePatient, { user: hcpUser2, role: TopicRole.PARTICIPANT })
-
-    const createdMessage = await createMessage(messageApiForHcp, hcpUser, null, createdTopic)
-
-    const message = await messageApiForHcp.getAndDecryptMessage(createdMessage.id!)
-
-    const filterChain = (hcpId: string, transportGuid: string) =>
-      new FilterChainMessage({
-        filter: new MessageByHcPartyTransportGuidFilter({
-          healthcarePartyId: hcpId,
-          transportGuid: transportGuid,
-        }),
-      })
-
-    const filterResultForHcp = await messageApiForHcp.filterMessagesBy(filterChain(hcpUser.healthcarePartyId!, message.transportGuid!))
-    expect(filterResultForHcp.rows).to.have.length(1)
-    expect(filterResultForHcp.rows!.find((m) => m.id === message.id)).to.deep.equal(message)
-
-    const filterResultForHcp2 = await messageApiForHcp2.filterMessagesBy(filterChain(hcpUser2.healthcarePartyId!, message.transportGuid!))
-    expect(filterResultForHcp2.rows).to.have.length(1)
-    expect(filterResultForHcp2.rows!.find((m) => m.id === message.id)).to.deep.equal(message)
-
-    const filterResultForHcp3 = await messageApiForHcp3.filterMessagesBy(filterChain(hcpUser3.healthcarePartyId!, message.transportGuid!))
-    expect(filterResultForHcp3.rows!.find((m) => m.id === message.id)).to.be.undefined
-  })
-
-  it('An HCP should be able to publish a message on a topic and a participant should be able to query it through LatestMessageByHcPartyTransportGuidFilter', async () => {
-    const {
-      userApi: userApiForHcp,
-      topicApi: topicApiForHcp,
-      patientApi: patientApiForHcp,
-      messageApi: messageApiForHcp,
-    } = await initApi(env!, hcp1Username)
-
-    const { userApi: userApiForHcp2, messageApi: messageApiForHcp2 } = await initApi(env!, hcp2Username)
-
-    const hcpUser = await userApiForHcp.getCurrentUser()
-    const hcpUser2 = await userApiForHcp2.getCurrentUser()
-
-    const samplePatient = await createPatient(patientApiForHcp, hcpUser)
-    const createdTopic = await createTopic(topicApiForHcp, hcpUser, samplePatient, { user: hcpUser2, role: TopicRole.PARTICIPANT })
-
-    let latestMessage: Message | null = null
-    for (let i = 0; i < 5; i++) {
-      // Creating 5 messages
-      latestMessage = await createMessage(messageApiForHcp, hcpUser, null, createdTopic)
-    }
-
-    const filterChain = (hcpId: string, transportGuid: string) =>
-      new FilterChainMessage({
-        filter: new LatestMessageByHcPartyTransportGuidFilter({
-          healthcarePartyId: hcpId,
-          transportGuid: transportGuid,
-        }),
-      })
-
-    const filterResultForHcp2 = await messageApiForHcp2.filterMessagesBy(filterChain(hcpUser2.healthcarePartyId!, latestMessage!.transportGuid!))
-    expect(filterResultForHcp2.rows).to.have.length(1) // Only one message should be returned
-    expect(filterResultForHcp2.rows![0]).to.deep.equal(latestMessage) // It should be the latest message
-  })
-
-  async function doXOnYAndSubscribe<Y>(
-    connectionPromise: Promise<Connection>,
-    x: () => Promise<Y>,
-    statusListener: (status: string) => void,
-    eventReceivedPromiseReject: (reason?: any) => void,
-    eventReceivedPromise: Promise<void>
-  ) {
-    const connection = (await connectionPromise)
-      .onClosed(async () => {
-        statusListener('CLOSED')
-        await sleep(3_000)
-      })
-      .onConnected(async () => {
-        statusListener('CONNECTED')
-        await sleep(2_000)
-        await x()
-      })
-
-    const timeout = setTimeout(eventReceivedPromiseReject, 20_000)
-    await eventReceivedPromise.then(() => clearTimeout(timeout)).catch(() => {})
-
-    connection.close()
-
-    await sleep(3_000)
-  }
-
-  const subscribeAndCreateMessage = async (options: SubscriptionOptions, eventTypes: ('CREATE' | 'DELETE' | 'UPDATE')[]) => {
-    const {
-      userApi: userApiForHcp,
-      topicApi: topicApiForHcp,
-      patientApi: patientApiForHcp,
-      messageApi: messageApiForHcp,
-    } = await initApi(env!, hcp2Username)
-
-    const loggedUser = await userApiForHcp.getCurrentUser()
-    const connectionPromise = async (options: {}, eventListener: (healthcareElement: Message) => Promise<void>) =>
-      messageApiForHcp.subscribeToMessageEvents(
-        eventTypes,
-        new MessageByHcPartyFilter({
-          hcpId: loggedUser!.healthcarePartyId!,
-        }),
-        eventListener,
-        options
-      )
-
-    const events: Message[] = []
-    const statuses: string[] = []
-
-    let eventReceivedPromiseResolve!: (value: void | PromiseLike<void>) => void
-    let eventReceivedPromiseReject!: (reason?: any) => void
-    const eventReceivedPromise = new Promise<void>((res, rej) => {
-      eventReceivedPromiseResolve = res
-      eventReceivedPromiseReject = rej
-    })
-
-    await doXOnYAndSubscribe(
-      connectionPromise(options, async (healthcareElement) => {
-        events.push(healthcareElement)
-        eventReceivedPromiseResolve()
-      }),
-      async () => {
-        const user = await userApiForHcp.getCurrentUser()
-
-        const patient = await patientApiForHcp.createPatientWithUser(
-          user,
-          await patientApiForHcp.newInstance(
-            user,
-            new Patient({
-              firstName: 'John',
-              lastName: 'Snow',
-              note: 'Winter is coming',
-            })
-          )
-        )
-
-        const topic = await topicApiForHcp.createTopic(
-          await topicApiForHcp.newInstance(
-            loggedUser,
-            patient,
-            new Topic({
-              description: 'Topic description',
-              activeParticipants: {
-                [loggedUser.healthcarePartyId!]: TopicRole.OWNER,
-              },
-            })
-          )
-        )
-
-        const createdMessage = await messageApiForHcp.encryptAndCreateMessageInTopic(
-          await messageApiForHcp.newInstanceWithPatient(
-            loggedUser,
-            null,
-            new Message({
-              id: randomUUID(),
-              subject: 'Message Subject',
-              sent: new Date().getTime(),
-              transportGuid: topic.id,
-              readStatus: Object.fromEntries(
-                Object.keys(topic.activeParticipants ?? {})
-                  .filter((hcpId) => hcpId != loggedUser.healthcarePartyId)
-                  .map((hcpId) => [hcpId, { read: false }])
-              ),
-              fromHealthcarePartyId: loggedUser.healthcarePartyId,
-            }),
-            {
-              additionalDelegates: {},
-            }
-          )
-        )
-      },
-      (status) => {
-        statuses.push(status)
-      },
-      eventReceivedPromiseReject,
-      eventReceivedPromise
-    )
-
-    events?.forEach((event) => console.log(`Event : ${event}`))
-    statuses?.forEach((status) => console.log(`Status : ${status}`))
-
-    expect(statuses).to.have.length(2)
-    expect(events).to.have.length(1)
-    expect(events.every((event) => event instanceof Message)).to.be.true
-  }
-
-  it('CREATE Message without options', async () => {
-    await subscribeAndCreateMessage({}, ['CREATE'])
-  }).timeout(60000)
-
-  it('CREATE Message with options', async () => {
-    await subscribeAndCreateMessage(
-      {
-        connectionRetryIntervalMs: 10_000,
-        connectionMaxRetry: 5,
-      },
-      ['CREATE']
-    )
-  }).timeout(60000)
-})?.timeout(60_000)
+})

--- a/test/utils/test_utils.ts
+++ b/test/utils/test_utils.ts
@@ -2,6 +2,7 @@ import {
   BasicAuthenticationProvider,
   CryptoPrimitives,
   CryptoStrategies,
+  EncryptedFieldsConfig,
   hex2ua,
   IcureApi,
   IcureApiOptions,
@@ -151,14 +152,19 @@ async function createHealthcarePartyUser(
   }
 }
 
-export async function createNewHcpApi(env: TestVars): Promise<{
+export async function createNewHcpApi(
+  env: TestVars,
+  options: {
+    encryptedFieldsConfig?: EncryptedFieldsConfig
+  } = {}
+): Promise<{
   api: IcureApi
   credentials: UserDetails
   user: User
 }> {
   const initialisationApi = await testSetupMasterApi(env)
   const primitives = new WebCryptoPrimitives(webcrypto as any)
-  const credentials = await createHealthcarePartyUser(initialisationApi, `user-${primitives.randomUuid()}`, primitives.randomUuid())
+  const credentials = await createHealthcarePartyUser(initialisationApi, `user-${primitives.randomUuid()}@icure.com`, primitives.randomUuid())
   const storage = await testStorageWithKeys([
     {
       dataOwnerId: credentials.dataOwnerId,
@@ -175,6 +181,7 @@ export async function createNewHcpApi(env: TestVars): Promise<{
       storage: storage.storage,
       keyStorage: storage.keyStorage,
       entryKeysFactory: storage.keyFactory,
+      encryptedFieldsConfig: options.encryptedFieldsConfig,
     }
   )
   return { api, credentials, user: await api.userApi.getCurrentUser() }


### PR DESCRIPTION
Add encryption to Document and Message apis. For all methods with Document/Message inputs or outputs:

- the base api implementation is overriden in the x api with a method that throws an exception (returns `never`)
- a new `xWithUser` method that encrypts inputs and decrypts outputs is added. The methods take as input a user to align with the existing implementations, but this user can be `undefined` as it is not actually used.

Other changes:

- Changes to existing `decrypt` method on Document
  - Removed unused parameter `hcpartyId`
  - Changed return type
  - Embedded attachment (encryptedAttachment / decryptedAttachment) is not handled automatically anymore. If needed we can add a `decryptEmbeddedAttachment`
- Removed message-in-topic methods
- Removed encrypted / decrypted message methods not following the `xWithUser` convention (replaced by the corresponding `xWithUser` method)
- Removed `DocumentXApi.findByMessage` (replaced by `findIdsByMessage`)
- Fixes and changes to `PatientXApi.export` method:
  - Remove using post parameter
  - Stop using deprecated get by patient id method, replaced by get ids by patient ids + batch retrieve
  - Fix return type
  - Return coherent entities: everything is decrypted if possible, stop using stubs.

