### PR TITLE
8.8.7: Fix ArrayBuffer issue in cloneDeep

### DIFF
--- a/icc-x-api/utils/collection-utils.ts
+++ b/icc-x-api/utils/collection-utils.ts
@@ -22,7 +22,29 @@ export function cloneDeep<T>(obj: T): T {
     return result as unknown as T
   }
 
+  // ArrayBuffer checks
+  const tag = Object.prototype.toString.call(obj)
+
+  // Raw buffers (not views) + realm safe check
+  if (obj instanceof ArrayBuffer || tag === '[object ArrayBuffer]') {
+    return (obj as unknown as ArrayBuffer).slice(0) as unknown as T
+  }
+
+  // Shared buffers + realm safe check
+  if (typeof SharedArrayBuffer !== 'undefined' && (obj instanceof SharedArrayBuffer || tag === '[object SharedArrayBuffer]')) {
+    const src = new Uint8Array(obj as unknown as SharedArrayBuffer)
+    const copy = new Uint8Array(src.byteLength)
+    copy.set(src)
+    return copy.buffer as unknown as T
+  }
+
+  // ArrayBuffer.isView does non-view ArrayBuffers (raw ArrayBuffers, SharedArrayBuffers)
   if (ArrayBuffer.isView(obj)) {
+    // Node Buffer: its .slice() shares memory, so it must be special-cased BEFORE the generic slice() path
+    if (typeof Buffer !== 'undefined' && Buffer.isBuffer(obj)) {
+      return Buffer.from(obj) as unknown as T // Buffer.from(buffer) copies
+    }
+
     if (obj instanceof DataView) {
       const clonedBuffer = obj.buffer.slice(obj.byteOffset, obj.byteOffset + obj.byteLength)
       return new DataView(clonedBuffer, 0, obj.byteLength) as unknown as T
@@ -44,8 +66,7 @@ export function cloneDeep<T>(obj: T): T {
 
     const clonedBuffer = view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength)
     const TypedArrayCtor = view.constructor as new (buffer: ArrayBuffer, byteOffset?: number, length?: number) => typeof obj
-    const length =
-      typeof view.BYTES_PER_ELEMENT === 'number' && typeof view.length === 'number' ? view.length : undefined
+    const length = typeof view.BYTES_PER_ELEMENT === 'number' && typeof view.length === 'number' ? view.length : undefined
     return new TypedArrayCtor(clonedBuffer, 0, length) as unknown as T
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icure/api",
-  "version": "8.8.6",
+  "version": "8.8.7",
   "description": "Typescript version of iCure standalone API client",
   "types": "dist/index.d.ts",
   "dependencies": {


### PR DESCRIPTION
Hotfix on top of 8.8.6.

## What
Cherry-picks `bb53b894` (Fixed ArrayBuffer issue in cloneDeep) onto the `support/8.8` line and bumps version to `8.8.7`.

## Changes
- `cloneDeep` now handles raw `ArrayBuffer`, `SharedArrayBuffer`, and Node `Buffer` correctly (deep copy instead of shared memory).
- Version `8.8.6` → `8.8.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)