### PR TITLE
feat!: restructure HealthElementAsserter to match cardinal-sdk 2.13.2

### DIFF
--- a/icc-api/model/HealthElementAsserter.ts
+++ b/icc-api/model/HealthElementAsserter.ts
@@ -1,3 +1,5 @@
+import { Identifier } from './Identifier'
+
 /**
  * The party asserting that the patient has the healthcare element this asserter is attached to.
  *
@@ -6,15 +8,29 @@
  * report a condition on behalf of the patient, and a physician may assert a diagnosis: all three are asserters, and the
  * same healthcare element may carry more than one of them.
  *
- * The two fields must agree: `asserterType` declares which kind of entity `asserterId` points at. The type bounds the
- * vocabulary, but nothing enforces the pairing: the field is encrypted, so the server never sees the values and cannot
- * validate or repair them.
+ * The party is named in exactly one of two ways, and exactly one of the two fields must be set:
+ * - `localAsserterIdentifier` names a party stored in this iCure instance: an id, plus the `AsserterTypeEnum` saying
+ *   which kind of record that id points at;
+ * - `externalAsserterIdentifier` names a party that has no record here, through a business `Identifier` issued by
+ *   another system. There is deliberately no asserter type on this branch: the kind of a record we do not store is not
+ *   knowable to us.
+ *
+ * Both fields of `LocalAsserterIdentifier` are required by the server and by the other iCure SDKs, and are declared
+ * optional here only because every model in this layer is. An asserter written with a partial local identifier cannot
+ * be read back by those SDKs.
+ *
+ * Do not rely on the server to enforce any of the above. `asserters` is encrypted by default (see
+ * `EncryptedFieldsConfig.Defaults.healthElement`), so the server usually sees only ciphertext and its own checks - the
+ * exactly-one rule, id not blank - never run. They do run for a client that overrides `encryptedFieldsConfig` for
+ * health elements without keeping `asserters` in the list, and a violation then surfaces as a `400`. The pairing inside
+ * `LocalAsserterIdentifier` is never checked anywhere: `AsserterTypeEnum` bounds the vocabulary, not what the id
+ * actually points at. All of these invariants are the caller's responsibility.
  *
  * Note on organisations: an organisation (hospital, practice, care home, ...) is not a distinct asserter type.
  * Organisations are stored as healthcare party records, distinguished from individual practitioners by tags set by the
- * client, so an organisation asserter is an entry with `asserterType = 'healthcareParty'` whose `asserterId` points to
- * such a record. The association between a practitioner and the organisation they were acting for at the time of the
- * assertion is deliberately not modelled here.
+ * client, so an organisation asserter is a `localAsserterIdentifier` with `type = 'healthcareParty'` whose `id` points
+ * to such a record. The association between a practitioner and the organisation they were acting for at the time of
+ * the assertion is deliberately not modelled here.
  */
 export class HealthElementAsserter {
   constructor(json: JSON | any) {
@@ -22,15 +38,46 @@ export class HealthElementAsserter {
   }
 
   /**
-   * The id of the entity making the assertion. Which entity it refers to is given by asserterType.
+   * The asserting party, as a reference to a record stored in this instance. Unset when the party is named by
+   * externalAsserterIdentifier.
    */
-  asserterId?: string
+  localAsserterIdentifier?: HealthElementAsserter.LocalAsserterIdentifier
   /**
-   * The kind of entity asserterId refers to. This is the entity-kind axis, not the role the party played in the
-   * assertion.
+   * The asserting party, as a business identifier from a system that is not this one. Unset when the party is named by
+   * localAsserterIdentifier. Carries no asserter type.
    */
-  asserterType?: HealthElementAsserter.AsserterTypeEnum
+  externalAsserterIdentifier?: Identifier
 }
+
 export namespace HealthElementAsserter {
+  /**
+   * A reference to the record, stored in iCure.
+   */
+  export class LocalAsserterIdentifier {
+    constructor(json: JSON | any) {
+      Object.assign(this as LocalAsserterIdentifier, json)
+    }
+
+    /**
+     * The id of the entity making the assertion. Which entity it refers to is given by type.
+     */
+    id?: string
+    /**
+     * The kind of entity id refers to. This is the entity-kind axis, not the role the party played in the assertion.
+     */
+    type?: AsserterTypeEnum
+  }
+
+  /**
+   * The kind of entity a LocalAsserterIdentifier id refers to.
+   *
+   * There is no entry for an organisation: organisations are stored as healthcare party records, so they use
+   * `healthcareParty` (see the note on the class).
+   */
   export type AsserterTypeEnum = 'patient' | 'healthcareParty' | 'relatedPerson'
+  export const AsserterTypeEnum = {
+    Patient: 'patient' as AsserterTypeEnum,
+    HealthcareParty: 'healthcareParty' as AsserterTypeEnum,
+    RelatedPerson: 'relatedPerson' as AsserterTypeEnum,
+  }
 }


### PR DESCRIPTION
Ports the `HealthElementAsserter` reshape from [cardinal-sdk 2.13.1...2.13.2](https://github.com/icure/cardinal-sdk/compare/2.13.1...2.13.2). That is the only substantive change in the upstream compare; everything else there is codegen whitespace and ordering.

## Breaking change

The flat `(asserterId, asserterType)` pair shipped in **8.13.0** is replaced by exactly one of two branches:

| field | names |
|---|---|
| `localAsserterIdentifier: { id, type }` | a party stored in this iCure instance |
| `externalAsserterIdentifier: Identifier` | a party from another system — deliberately carries no asserter type, since the kind of a record we do not store is not knowable to us |

Asserters written by 8.13.0 are **not** read back: their keys survive decryption but no accessor sees them. `asserters` is encrypted, so the server can neither validate nor migrate them. Upstream reshaped the same model one day after first shipping the flat form, so stored data in the wild is unlikely.

## Why the field names matter

The nested identifier uses `id`/`type`, matching how cardinal-sdk serialises `LocalAsserterIdentifier`:

```kotlin
public data class LocalAsserterIdentifier(
    public val id: String,
    public val type: AsserterType,
)
```

Keeping `asserterId`/`asserterType` would have produced asserters that no other iCure SDK could decode — `kotlinx.serialization` throws on the missing required `id`/`type`, and the ts-wrapper's `fromJSON` reads both with `required = true`.

## Other changes

- `LocalAsserterIdentifier` is nested under the `HealthElementAsserter` namespace, as upstream has it, rather than leaking a name that generic as a top-level export of `@icure/api`.
- Both classes use the layer's `constructor(json)` + `Object.assign` convention, so they stay constructible from decrypted JSON.
- `AsserterTypeEnum` gains the usual runtime companion object, matching `HealthElement.LateralityEnum`.
- Docs rewritten from upstream, adapted where this SDK differs: upstream leans on kraken's `init` check for the exactly-one rule, but `asserters` is in `EncryptedFieldsConfig.Defaults.healthElement`, so the server normally sees only ciphertext and those checks never run. The doc now says so, and notes they *do* run for a client that overrides `encryptedFieldsConfig` without keeping `asserters` in the list.
- `id`/`type` stay optional because every model in `icc-api/model` is; the doc states they are required by the server and the other SDKs.

## Verification

- `npx tsc --noEmit` — clean
- `npx prettier --check` — clean

## Not in this PR

- **`RELEASES.md` + version bump.** `package.json` is still at the released 8.13.0, whose note describes the old shape. Left for `/tsdk-release`, which drafts the entry — the breaking-change text above can be lifted into it.
- **Test coverage.** `asserters` is the only entry in `Defaults.healthElement` that is an array of nested objects, i.e. the one field exercising `encryptObject`'s non-flat path, and `test/` has no reference to it. A round-trip test pinning `{localAsserterIdentifier:{id,type}}` would guard the wire shape against the next rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)